### PR TITLE
Add 'limit', 'offset' and 'order' methods

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,9 +98,10 @@ convention = "google"
 
 [tool.ruff.lint.extend-per-file-ignores]
 "tests/**/*.py" = [
-  "S101",   # we can (and MUST!) use 'assert' in test files.
-  "ANN001", # annotations for fixtures are sometimes a pain for test files
-  "ARG00",  # test fixtures often are not directly used
+  "S101",    # we can (and MUST!) use 'assert' in test files.
+  "ANN001",  # annotations for fixtures are sometimes a pain for test files
+  "ARG00",   # test fixtures often are not directly used
+  "PLR2004", # magic numbers are often used in test files
 ]
 
 [tool.ruff.lint.isort]

--- a/sqliter/exceptions.py
+++ b/sqliter/exceptions.py
@@ -1,10 +1,16 @@
-"""Define custom exceptins for the sqliter package."""
+"""Define custom exceptions for the sqliter package."""
 
 
-class InvalidOffsetError(ValueError):
+class SqliterError(Exception):
+    """Base class for all exceptions raised by the sqliter package."""
+
+
+class InvalidOffsetError(SqliterError):
     """Raised when an invalid offset value (0 or negative) is used."""
 
     def __init__(self, offset_value: int) -> None:
+        """Pass the message up to the base Exception."""
         super().__init__(
-            f"Invalid offset value: {offset_value}. Offset must be a positive integer."
+            f"Invalid offset value: {offset_value}. "
+            "Offset must be a positive integer."
         )

--- a/sqliter/query/query.py
+++ b/sqliter/query/query.py
@@ -33,6 +33,7 @@ class QueryBuilder:
         return self
 
     def limit(self, limit_value: int) -> Self:
+        """Limit the number of results returned by the query."""
         self._limit = limit_value
         return self
 
@@ -47,6 +48,7 @@ class QueryBuilder:
         return self
 
     def order(self, order_by_field: str) -> Self:
+        """Order the results by a specific field and optionally direction."""
         self._order_by = order_by_field
         return self
 
@@ -82,8 +84,6 @@ class QueryBuilder:
 
         # Only include non-None values in the values list
         values = [value for _, value in self.filters if value is not None]
-
-        print(sql)
 
         with self.db.connect() as conn:
             cursor = conn.cursor()

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -234,7 +234,7 @@ def test_filter_single_condition(db_mock) -> None:
     # Assert that the filter works and returns the correct record
     assert len(results) == 1
     assert results[0].name == "John Doe"
-    assert results[0].age == 30  # noqa: PLR2004
+    assert results[0].age == 30
 
 
 def test_filter_multiple_conditions(db_mock) -> None:
@@ -264,7 +264,7 @@ def test_filter_multiple_conditions(db_mock) -> None:
     # Assert that the filter works and returns the correct record
     assert len(results) == 1
     assert results[0].name == "John Doe"
-    assert results[0].age == 30  # noqa: PLR2004
+    assert results[0].age == 30
 
 
 def test_filter_no_matching_results(db_mock) -> None:
@@ -315,7 +315,7 @@ def test_filter_numeric_condition(db_mock) -> None:
     # Assert that the filter works and returns the correct record
     assert len(results) == 1
     assert results[0].name == "John Smith"
-    assert results[0].age == 40  # noqa: PLR2004
+    assert results[0].age == 40
 
 
 def test_filter_multiple_results(db_mock) -> None:
@@ -439,8 +439,6 @@ def test_order(db_mock) -> None:
     # Perform a query with ordering by name DESC
     results = db_mock.select(OrderTestModel).order("name DESC").fetch_all()
 
-    print([result.name for result in results])
-
     # Assert that the ordering works in descending order
     assert len(results) == 3
     assert results[0].name == "John Doe"
@@ -520,12 +518,14 @@ def test_offset_edge_cases(db_mock) -> None:
     db_mock.insert(EdgeCaseOffsetModel(name="Jane Doe"))
 
     # Offset with zero should raise InvalidOffsetError
-    with pytest.raises(InvalidOffsetError):
+    with pytest.raises(InvalidOffsetError) as exc:
         db_mock.select(EdgeCaseOffsetModel).offset(0).fetch_all()
+    assert "Invalid offset value: 0" in str(exc.value)
 
     # Negative offset should raise InvalidOffsetError
-    with pytest.raises(InvalidOffsetError):
+    with pytest.raises(InvalidOffsetError) as exc:
         db_mock.select(EdgeCaseOffsetModel).offset(-1).fetch_all()
+    assert "Invalid offset value: -1" in str(exc.value)
 
     # Valid offset should work normally
     results = db_mock.select(EdgeCaseOffsetModel).offset(1).fetch_all()

--- a/tests/test_sqliter.py
+++ b/tests/test_sqliter.py
@@ -128,7 +128,7 @@ def test_create_table_with_custom_auto_increment_pk(db_mock) -> None:
 
     # Check that the custom_id column auto-incremented
     assert results[0][0] == 1
-    assert results[1][0] == 2  # noqa: PLR2004
+    assert results[1][0] == 2
     assert results[0][1] == "First Entry"
     assert results[1][1] == "Second Entry"
 
@@ -268,7 +268,7 @@ def test_count_records(db_mock) -> None:
     db_mock.insert(license2)
 
     count = db_mock.select(ExampleModel).count()
-    assert count == 2  # noqa: PLR2004
+    assert count == 2
 
 
 def test_exists_record(db_mock) -> None:


### PR DESCRIPTION
These can be chained between the select method and the last execution method (fetch_all etc).

- `limit()`
- `offset()`
- `order()`

These do basically as the equivalent SQL keywords would do