### PR TITLE
remove transaction exception (TransactionError)

### DIFF
--- a/sqliter/exceptions.py
+++ b/sqliter/exceptions.py
@@ -93,7 +93,7 @@ class RecordUpdateError(SqliterError):
 class RecordNotFoundError(SqliterError):
     """Raised when a record with the specified primary key is not found."""
 
-    message_template = "No record found for key '{}'"
+    message_template = "Failed to find a record for key '{}' "
 
 
 class RecordFetchError(SqliterError):
@@ -111,10 +111,4 @@ class RecordDeletionError(SqliterError):
 class InvalidFilterError(SqliterError):
     """Raised when an invalid filter field is used in a query."""
 
-    message_template = "Invalid filter field: '{}'"
-
-
-class TransactionError(SqliterError):
-    """Raised when an error occurs during a transaction."""
-
-    message_template = "Transaction failed in table: '{}'"
+    message_template = "Failed to apply filter: invalid field '{}'"

--- a/sqliter/sqliter.py
+++ b/sqliter/sqliter.py
@@ -15,7 +15,6 @@ from sqliter.exceptions import (
     RecordNotFoundError,
     RecordUpdateError,
     TableCreationError,
-    TransactionError,
 )
 from sqliter.query.query import QueryBuilder
 
@@ -188,6 +187,7 @@ class SqliterDB:
             with self.connect() as conn:
                 cursor = conn.cursor()
                 cursor.execute(delete_sql, (primary_key_value,))
+
                 if cursor.rowcount == 0:
                     raise RecordNotFoundError(primary_key_value)
                 self._maybe_commit(conn)
@@ -216,7 +216,6 @@ class SqliterDB:
                 if exc_type:
                     # Roll back the transaction if there was an exception
                     self.conn.rollback()
-                    raise TransactionError(self.conn) from exc_value
                 self._maybe_commit(self.conn)
             finally:
                 # Close the connection and reset the instance variable

--- a/tests/test_sqliter.py
+++ b/tests/test_sqliter.py
@@ -5,7 +5,6 @@ from sqliter import SqliterDB
 from sqliter.exceptions import (
     RecordFetchError,
     RecordNotFoundError,
-    TransactionError,
 )
 from sqliter.model import BaseDBModel
 
@@ -354,7 +353,9 @@ def test_update_non_existing_record(db_mock) -> None:
         db_mock.update(example_model)
 
     # Check that the correct error message is raised
-    assert "No record found for key 'nonexistent'" in str(exc_info.value)
+    assert "Failed to find a record for key 'nonexistent'" in str(
+        exc_info.value
+    )
 
 
 def test_get_non_existent_table(db_mock) -> None:
@@ -423,14 +424,14 @@ def test_transaction_closes_connection(db_mock, mocker) -> None:
 
 
 def test_transaction_rollback_on_exception(db_mock, mocker) -> None:
-    """Test that the transaction rolls back and raises our custom exception."""
+    """Test that the transaction rolls back when an exception occurs."""
     # Mock the connection object and ensure it's set as db_mock.conn
     mock_conn = mocker.Mock()
     mocker.patch.object(db_mock, "conn", mock_conn)
 
     # Simulate an exception within the context manager
     message = "Simulated error"
-    with pytest.raises(TransactionError), db_mock:
+    with pytest.raises(ValueError, match=message), db_mock:
         raise ValueError(message)
 
     # Ensure rollback was called on the mocked connection


### PR DESCRIPTION
Really this was not needed since there are more specific exceptions that can be allowed to bubble. The rollback is still explicitly called for any exception though.