### PR TITLE
implement an in-memory database option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -218,3 +218,4 @@ pyrightconfig.json
 .changelog_generator.toml
 repopack-output.xml
 .envrc
+demo-db

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ database-like format without needing to learn SQL or use a full ORM.
   - [Defining Models](#defining-models)
   - [Database Operations](#database-operations)
     - [Creating a Connection](#creating-a-connection)
+    - [Using an In-Memory Database](#using-an-in-memory-database)
     - [Creating Tables](#creating-tables)
     - [Inserting Records](#inserting-records)
     - [Querying Records](#querying-records)
@@ -187,6 +188,36 @@ db = SqliterDB("your_database.db", auto_commit=False)
 It is then up to you to manually commit changes using the `commit()` method.
 This can be useful when you want to perform multiple operations in a single
 transaction without the overhead of committing after each operation.
+
+#### Using an In-Memory Database
+
+If you want to use an in-memory database, you can set `memory=True` when
+creating the database connection:
+
+```python
+db = SqliterDB(memory=True)
+```
+
+This will create an in-memory database that is not persisted to disk. If you
+also specify a database name, it will be ignored.
+
+```python
+db = SqliterDB("ignored.db", memory=True)
+```
+
+The `ignored.db` file will not be created, and the database will be in-memory.
+If you do not specify a database name, and do NOT set `memory=True`, an
+exception will be raised.
+
+> [!NOTE]
+>
+> You can also use `":memory:"` as the database name (same as normal with
+> Sqlite) to create an in-memory database, this is just a cleaner and more
+> descriptive way to do it.
+>
+> ```python
+> db = SqliterDB(":memory:")
+> ```
 
 #### Creating Tables
 

--- a/TODO.md
+++ b/TODO.md
@@ -11,7 +11,6 @@
 - add a 'drop_table' method to the main class to allow dropping tables.
 - add a method to drop the entire database easiest way is prob to just delete
   and recreate the database file.
-- add an option to work completely in memory, good for temporary databases.
 - add an 'exists_ok' (default True) parameter to the 'create_table' method so it
   will raise an exception if the table already exists and this is set to False.
 - add a `rollback` method to the main class to allow manual rollbacks.

--- a/demo.py
+++ b/demo.py
@@ -29,7 +29,7 @@ class UserModel(BaseDBModel):
 
 def main() -> None:
     """Simple example to demonstrate the usage of the 'sqliter' package."""
-    db = SqliterDB("demo.db", auto_commit=True)
+    db = SqliterDB("./demo-db/demo.db", auto_commit=True)
     with db:
         db.create_table(UserModel)  # Create the users table
         user1 = UserModel(

--- a/sqliter/sqliter.py
+++ b/sqliter/sqliter.py
@@ -27,9 +27,24 @@ if TYPE_CHECKING:  # pragma: no cover
 class SqliterDB:
     """Class to manage SQLite database interactions."""
 
-    def __init__(self, db_filename: str, *, auto_commit: bool = True) -> None:
+    def __init__(
+        self,
+        db_filename: Optional[str] = None,
+        *,
+        memory: bool = False,
+        auto_commit: bool = True,
+    ) -> None:
         """Initialize the class and options."""
-        self.db_filename = db_filename
+        if memory:
+            self.db_filename = ":memory:"
+        elif db_filename:
+            self.db_filename = db_filename
+        else:
+            err = (
+                "Database name must be provided if not using an in-memory "
+                "database."
+            )
+            raise ValueError(err)
         self.auto_commit = auto_commit
         self.conn: Optional[sqlite3.Connection] = None
 


### PR DESCRIPTION
Add the `memory=True` arg to the `SQLiterDB` constructor. This will explicitly create an in-memory database