### PR TITLE
rename 'create_id' to 'create_pk'

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,13 +185,13 @@ class User(BaseDBModel):
     class Meta:
         table_name = "users"
         primary_key = "name"  # Default is "id"
-        create_id = False  # disable auto-creating an incrementing primary key - default is True
+        create_pk = False  # disable auto-creating an incrementing primary key - default is True
 ```
 
 For a standard database with an auto-incrementing integer 'id' primary key, you
-do not need to specify the `primary_key` or `create_id` fields. If you want to
-specify a different primary key field, you can do so using the `primary_key`
-field in the `Meta` class.
+do not need to specify the `primary_key` or `create_pk` fields. If you want to
+specify a different primary key field name, you can do so using the
+`primary_key` field in the `Meta` class.
 
 If `table_name` is not specified, the table name will be the same as the model
 name, converted to 'snake_case' and pluralized (e.g., `User` -> `users`). Also,

--- a/TODO.md
+++ b/TODO.md
@@ -1,7 +1,5 @@
 # TODO
 
-- BREAKING: change the 'create_id' meta field to 'create_pk' as it may not be
-  called 'id' in the model.
 - add an option to the SQLiter constructor to delete the database file if it
   already exists. Default to False.
 - add attributes to the BaseDBModel to read the table-name, file-name, is-memory
@@ -18,7 +16,7 @@
 - add an 'exists_ok' (default True) parameter to the 'create_table' method so it
   will raise an exception if the table already exists and this is set to False.
 - add a `rollback` method to the main class to allow manual rollbacks.
-- allow adding multiple indexes to each table as well as the primary index.
+- allow adding multiple indexes to each table as well as the primary key.
 - allow adding foreign keys and relationships to each table.
 - add a migration system to allow updating the database schema without losing
   data.

--- a/demo.py
+++ b/demo.py
@@ -22,7 +22,7 @@ class UserModel(BaseDBModel):
     class Meta:
         """Override the default options for the UserModel."""
 
-        create_id: bool = False  # Disable auto-increment ID
+        create_pk: bool = False  # Disable auto-increment ID
         primary_key: str = "slug"  # Use 'slug' as the primary key
         table_name: str = "users"  # Explicitly define the table name
 

--- a/sqliter/model/model.py
+++ b/sqliter/model/model.py
@@ -23,8 +23,10 @@ class BaseDBModel(BaseModel):
     class Meta:
         """Configure the base model with default options."""
 
-        create_id: bool = True  # Whether to create an auto-increment ID
-        primary_key: str = "id"  # Default primary key field
+        create_pk: bool = (
+            True  # Whether to create an auto-increment primary key
+        )
+        primary_key: str = "id"  # Default primary key name
         table_name: Optional[str] = (
             None  # Table name, defaults to class name if not set
         )
@@ -97,6 +99,6 @@ class BaseDBModel(BaseModel):
         return getattr(cls.Meta, "primary_key", "id")
 
     @classmethod
-    def should_create_id(cls) -> bool:
+    def should_create_pk(cls) -> bool:
         """Check whether the model should create an auto-increment ID."""
-        return getattr(cls.Meta, "create_id", True)
+        return getattr(cls.Meta, "create_pk", True)

--- a/sqliter/sqliter.py
+++ b/sqliter/sqliter.py
@@ -73,13 +73,13 @@ class SqliterDB:
         """Create a table based on the Pydantic model."""
         table_name = model_class.get_table_name()
         primary_key = model_class.get_primary_key()
-        create_id = model_class.should_create_id()
+        create_pk = model_class.should_create_pk()
 
         fields = ", ".join(
             f"{field_name} TEXT" for field_name in model_class.model_fields
         )
 
-        if create_id:
+        if create_pk:
             create_table_sql = f"""
                 CREATE TABLE IF NOT EXISTS {table_name} (
                     {primary_key} INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,7 +39,7 @@ class ExampleModel(BaseDBModel):
     class Meta:
         """Configuration for the model."""
 
-        create_id: bool = False
+        create_pk: bool = False
         primary_key: str = "slug"
         table_name: str = "test_table"
 
@@ -53,7 +53,7 @@ class PersonModel(BaseDBModel):
     class Meta:
         """Configuration for the model."""
 
-        create_id = False
+        create_pk = False
         table_name = "person_table"
         primary_key = "name"
 
@@ -73,7 +73,7 @@ class DetailedPersonModel(BaseDBModel):
 
         table_name = "detailed_person_table"
         primary_key = "name"
-        create_id = False
+        create_pk = False
 
 
 class ComplexModel(BaseDBModel):
@@ -91,7 +91,7 @@ class ComplexModel(BaseDBModel):
 
         table_name = "complex_model"
         primary_key = "id"
-        create_id = False
+        create_pk = False
 
 
 @pytest.fixture

--- a/tests/test_sqliter.py
+++ b/tests/test_sqliter.py
@@ -90,7 +90,7 @@ def test_create_table_with_auto_increment(db_mock) -> None:
         name: str
 
         class Meta:
-            create_id: bool = True  # Enable auto-increment ID
+            create_pk: bool = True  # Enable auto-increment ID
             primary_key: str = "id"  # Default primary key is 'id'
             table_name: str = "auto_increment_table"
 
@@ -117,7 +117,7 @@ def test_create_table_with_custom_primary_key(db_mock) -> None:
         description: str
 
         class Meta:
-            create_id: bool = False  # Disable auto-increment ID
+            create_pk: bool = False  # Disable auto-increment ID
             primary_key: str = "code"  # Use 'code' as the primary key
             table_name: str = "custom_pk_table"
 
@@ -143,7 +143,7 @@ def test_create_table_with_custom_auto_increment_pk(db_mock) -> None:
         name: str
 
         class Meta:
-            create_id: bool = True  # Enable auto-increment ID
+            create_pk: bool = True  # Enable auto-increment ID
             primary_key: str = "custom_id"  # Use 'custom_id' as the primary key
             table_name: str = "custom_auto_increment_pk_table"
 


### PR DESCRIPTION
Rename this since the primary key may not always be called 'id'. The default name for the PK is still 'id' though, maybe this should change too?