### PR TITLE
deprecate 'direction=' for 'reverse=' in `order()` method.

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ database-like format without needing to learn SQL or use a full ORM.
     - [Commit your changes](#commit-your-changes)
     - [Close the Connection](#close-the-connection)
   - [Transactions](#transactions)
+  - [Ordering](#ordering)
   - [Field Control](#field-control)
     - [Selecting Specific Fields](#selecting-specific-fields)
     - [Excluding Specific Fields](#excluding-specific-fields)
@@ -282,7 +283,7 @@ all_users = db.select(User).fetch_all()
 young_users = db.select(User).filter(age=25).fetch_all()
 
 # Order users
-ordered_users = db.select(User).order("age", direction="DESC").fetch_all()
+ordered_users = db.select(User).order("age", reverse=True).fetch_all()
 
 # Limit and offset
 paginated_users = db.select(User).limit(10).offset(20).fetch_all()
@@ -354,6 +355,24 @@ with db:
 >
 > the `close()` method will also be called when the context manager exits, so you
 > do not need to call it manually.
+
+### Ordering
+
+For now we only support ordering by the single field. You can specify the
+field to order by and whether to reverse the order:
+
+```python
+results = db.select(User).order("age", reverse=True).fetch_all()
+```
+
+This will order the results by the `age` field in descending order.
+
+> [!WARNING]
+>
+> Previously ordering was done using the `direction` parameter with `asc` or
+> `desc`, but this has been deprecated in favor of using the `reverse`
+> parameter. The `direction` parameter still works, but will raise a
+> `DeprecationWarning` and will be removed in a future release.
 
 ### Field Control
 

--- a/TODO.md
+++ b/TODO.md
@@ -4,9 +4,6 @@
   already exists. Default to False.
 - add attributes to the BaseDBModel to read the table-name, file-name, is-memory
   etc.
-- deprectate 'direction=' in the 'order' method and replace with 'reverse=' with
-  a default of False. Leave the 'direction=' parameter in place for now but
-  raise a deprecation warning if it is used.
 - add an 'execute' method to the main class to allow executing arbitrary SQL
   queries which can be chained to the 'find_first' etc methods or just used
   directly.

--- a/TODO.md
+++ b/TODO.md
@@ -17,8 +17,6 @@
 - allow adding foreign keys and relationships to each table.
 - add a migration system to allow updating the database schema without losing
   data.
-- add support for more data types, though since it is using Pydantic it should
-  be quite comprehensive already.
 - add debug logging to show the SQL queries being executed.
 - add more tests where 'auto_commit' is set to False to ensure that commit is
   not called automatically.
@@ -28,10 +26,12 @@
   The return model is created using the pydantic model, so these are converted
   correctly anyway, but it would be nice to have the database schema match the
   model schema.
-- support structures like, `list`, `dict`, `set` etc. in the model. This
-  will need to be stored as a JSON string or pickled in the database. Also
-  support `date` which can be either stored as a string or more useful as a Unix
-  timestamp in an integer field.
+- support structures like, `list`, `dict`, `set` etc. in the model. This will
+  need to be stored as a JSON string or pickled in the database (the latter
+  would be more versatile). Also support `date` which can be either stored as a
+  string or more useful as a Unix timestamp in an integer field.
+- for the `order()` allow ommitting the field name and just specifying the
+  direction. This will default to the primary key field.
 
 ## Potential Filter Additions
 

--- a/demo.py
+++ b/demo.py
@@ -29,7 +29,7 @@ class UserModel(BaseDBModel):
 
 def main() -> None:
     """Simple example to demonstrate the usage of the 'sqliter' package."""
-    db = SqliterDB("./demo-db/demo.db", auto_commit=True)
+    db = SqliterDB(memory=True, auto_commit=True)
     with db:
         db.create_table(UserModel)  # Create the users table
         user1 = UserModel(
@@ -66,6 +66,11 @@ def main() -> None:
 
         all_users = db.select(UserModel).fetch_all()
         logging.info(all_users)
+
+        all_reversed = (
+            db.select(UserModel).order("name", reverse=True).fetch_all()
+        )
+        logging.info(all_reversed)
 
         fetched_user = db.get(UserModel, "jdoe2")
         logging.info(fetched_user)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,7 +132,9 @@ module = "tests.*"
 
 [tool.pytest.ini_options]
 addopts = ["--cov", "--cov-report", "term-missing", "--cov-report", "html"]
-filterwarnings = []
+filterwarnings = [
+  "ignore:'direction' argument is deprecated:DeprecationWarning",
+]
 mock_use_standalone_module = true
 
 [tool.coverage.run]

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -453,7 +453,51 @@ def test_order_default(db_mock) -> None:
     assert results[2].name == "John Doe"
 
 
-def test_order_ascending(db_mock) -> None:
+def test_order_with_reverse_false(db_mock) -> None:
+    """Test that the order method works with reverse=False (ascending order)."""
+
+    class TestModel(BaseDBModel):
+        name: str
+
+        class Meta:
+            table_name = "test_table"
+
+    db_mock.create_table(TestModel)
+    db_mock.insert(TestModel(name="Charlie"))
+    db_mock.insert(TestModel(name="Alice"))
+    db_mock.insert(TestModel(name="Bob"))
+
+    # Ascending order
+    results = db_mock.select(TestModel).order("name", reverse=False).fetch_all()
+    assert len(results) == 3
+    assert results[0].name == "Alice"
+    assert results[1].name == "Bob"
+    assert results[2].name == "Charlie"
+
+
+def test_order_with_reverse_true(db_mock) -> None:
+    """Test that the order method works with reverse=True (descending order)."""
+
+    class TestModel(BaseDBModel):
+        name: str
+
+        class Meta:
+            table_name = "test_table"
+
+    db_mock.create_table(TestModel)
+    db_mock.insert(TestModel(name="Charlie"))
+    db_mock.insert(TestModel(name="Alice"))
+    db_mock.insert(TestModel(name="Bob"))
+
+    # Descending order
+    results = db_mock.select(TestModel).order("name", reverse=True).fetch_all()
+    assert len(results) == 3
+    assert results[0].name == "Charlie"
+    assert results[1].name == "Bob"
+    assert results[2].name == "Alice"
+
+
+def test_order_direction_ascending(db_mock) -> None:
     """Test that the order method works as expected when ASC specified."""
 
     # Define a simple model for the test
@@ -483,7 +527,7 @@ def test_order_ascending(db_mock) -> None:
     assert results[2].name == "John Doe"
 
 
-def test_order_desc(db_mock) -> None:
+def test_order_direction_desc(db_mock) -> None:
     """Test that the order method works as expected descending."""
 
     # Define a simple model for the test
@@ -511,6 +555,39 @@ def test_order_desc(db_mock) -> None:
     assert results[0].name == "John Doe"
     assert results[1].name == "Jim Doe"
     assert results[2].name == "Jane Doe"
+
+
+def test_order_with_both_reverse_and_direction(db_mock) -> None:
+    """Test that  both 'direction' and 'reverse' raises an InvalidOrderError."""
+
+    class TestModel(BaseDBModel):
+        name: str
+
+        class Meta:
+            table_name = "test_table"
+
+    db_mock.create_table(TestModel)
+    db_mock.insert(TestModel(name="Charlie"))
+    db_mock.insert(TestModel(name="Alice"))
+    db_mock.insert(TestModel(name="Bob"))
+
+    # Both 'reverse' and 'direction' specified (should raise error)
+    with pytest.raises(
+        InvalidOrderError, match="Cannot specify both 'direction' and 'reverse'"
+    ):
+        db_mock.select(TestModel).order("name", direction="ASC", reverse=True)
+
+
+def test_order_deprecation_warning(db_mock) -> None:
+    """Test that using 'direction' raises a DeprecationWarning."""
+
+    class TestModel(BaseDBModel):
+        name: str
+
+    with pytest.warns(
+        DeprecationWarning, match="'direction' argument is deprecated"
+    ):
+        db_mock.select(TestModel).order("name", direction="ASC")
 
 
 def test_limit_offset_order_combined(db_mock) -> None:


### PR DESCRIPTION
Using `reverse=True` (or False) is clearer and does not require any knowledge of the underlying SQL syntax.

`direction=` still works, but is deprecated and will raise a warning.