### PR TITLE
try to create relevant db fields

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -139,6 +139,7 @@ keep-runtime-typing = true
 
 [tool.mypy]
 python_version = "3.9"
+exclude = ["docs"]
 
 [[tool.mypy.overrides]]
 disable_error_code = ["method-assign", "no-untyped-def", "attr-defined"]

--- a/sqliter/constants.py
+++ b/sqliter/constants.py
@@ -18,3 +18,12 @@ OPERATOR_MAPPING = {
     "__iendswith": "LIKE",
     "__icontains": "LIKE",
 }
+
+# Mapping of Python types to SQLite types
+SQLITE_TYPE_MAPPING = {
+    int: "INTEGER",
+    float: "REAL",
+    str: "TEXT",
+    bool: "INTEGER",  # SQLite stores booleans as integers (0 or 1)
+    bytes: "BLOB",
+}

--- a/sqliter/helpers.py
+++ b/sqliter/helpers.py
@@ -1,0 +1,22 @@
+"""Define helper functions used in the library."""
+
+from typing import Union
+
+from sqliter.constants import SQLITE_TYPE_MAPPING
+
+
+def infer_sqlite_type(field_type: Union[type, None]) -> str:
+    """Infer the SQLite column type based on the Python/Pydantic type.
+
+    Args:
+        field_type: The type of the field (e.g., int, str, etc.)
+
+    Returns:
+        The corresponding SQLite type as a string (e.g., INTEGER, REAL, TEXT).
+    """
+    # If field_type is None, default to TEXT
+    if field_type is None:
+        return "TEXT"
+
+    # Map the simplified type to an SQLite type
+    return SQLITE_TYPE_MAPPING.get(field_type, "TEXT")


### PR DESCRIPTION
use more relevant field types in sqlite rather than a blanket `TEXT` - though to be honest this is not really relevant as sqlite is very forgiving and will accept pretty much any value in a field irrespective of the defined type. 

At this time Union[] types will still be stored as TEXT, until I can find an implementation that does not break tests.