### PR TITLE
add `drop_table` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - Add test coverage where missing ([#28](https://github.com/seapagan/sqliter-py/pull/28)) by [seapagan](https://github.com/seapagan)
 
+**Refactoring**
+
+- Perform some internal refactoring, mostly arranging the tests. ([#30](https://github.com/seapagan/sqliter-py/pull/30)) by [seapagan](https://github.com/seapagan)
+
 **Documentation**
 
 - Add a documentation website and trim down the README ([#25](https://github.com/seapagan/sqliter-py/pull/25)) by [seapagan](https://github.com/seapagan)

--- a/TODO.md
+++ b/TODO.md
@@ -9,7 +9,6 @@
 - add an 'execute' method to the main class to allow executing arbitrary SQL
   queries which can be chained to the 'find_first' etc methods or just used
   directly.
-- add a 'drop_table' method to the main class to allow dropping tables.
 - add a method to drop the entire database easiest way is prob to just delete
   and recreate the database file.
 - add an 'exists_ok' (default True) parameter to the 'create_table' method so it
@@ -21,16 +20,11 @@
   data.
 - add more tests where 'auto_commit' is set to False to ensure that commit is
   not called automatically.
-- the database is created with every field as TEXT. We should try to infer the
-  correct type from the Pydantic model and map it to the correct SQLite type.
-  The return model is created using the pydantic model, so these are converted
-  correctly anyway, but it would be nice to have the database schema match the
-  model schema.
 - support structures like, `list`, `dict`, `set` etc. in the model. This will
   need to be stored as a JSON string or pickled in the database (the latter
   would be more versatile). Also support `date` which can be either stored as a
   string or more useful as a Unix timestamp in an integer field.
-- for the `order()` allow ommitting the field name and just specifying the
+- for the `order()` allow omitting the field name and just specifying the
   direction. This will default to the primary key field.
 
 ## Potential Filter Additions

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -97,6 +97,22 @@ exception will be raised.
 db.create_table(User)
 ```
 
+> [!IMPORTANT]
+>
+> The Table is created **regardless** of the `auto_commit` setting.
+
+### Dropping Tables
+
+```python
+db.drop_table(User)
+```
+
+> [!IMPORTANT]
+>
+> The Table is dropped **regardless** of the `auto_commit` setting.
+
+## Data operations
+
 ### Inserting Records
 
 ```python

--- a/sqliter/exceptions.py
+++ b/sqliter/exceptions.py
@@ -133,3 +133,9 @@ class InvalidFilterError(SqliterError):
     """Exception raised when an invalid filter is applied to a query."""
 
     message_template = "Failed to apply filter: invalid field '{}'"
+
+
+class TableDeletionError(SqliterError):
+    """Raised when a table cannot be deleted from the database."""
+
+    message_template = "Failed to delete the table: '{}'"

--- a/tests/test_debug_logging.py
+++ b/tests/test_debug_logging.py
@@ -244,3 +244,15 @@ class TestDebugLogging:
             'Executing SQL: SELECT "id", "name", "age", "is_active", "score", '
             '"nullable_field" FROM "complex_model"' in caplog.text
         )
+
+    def test_debug_output_drop_table(
+        self, db_mock_complex_debug: SqliterDB, caplog
+    ) -> None:
+        """Test debug output when dropping a table."""
+        with caplog.at_level(logging.DEBUG):
+            db_mock_complex_debug.drop_table(ComplexModel)
+
+        # Assert the SQL query for dropping the table was logged
+        assert (
+            "Executing SQL: DROP TABLE IF EXISTS complex_model" in caplog.text
+        )

--- a/tests/test_drop_table.py
+++ b/tests/test_drop_table.py
@@ -1,0 +1,102 @@
+"""Test the 'drop_table' method of the 'SqliterDB' class."""
+
+import sqlite3
+
+import pytest
+
+from sqliter import SqliterDB
+from sqliter.exceptions import TableDeletionError
+from sqliter.model import BaseDBModel
+
+
+class TestDropTable:
+    """Test class for the 'drop_table' method."""
+
+    def test_drop_existing_table(self, db_mock) -> None:
+        """Test dropping an existing table."""
+
+        class TestModel(BaseDBModel):
+            name: str
+
+            class Meta:
+                table_name = "test_drop_table"
+
+        db_mock.create_table(TestModel)
+        db_mock.drop_table(TestModel)
+
+        # Verify the table no longer exists
+        with db_mock.connect() as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' "
+                "AND name='test_drop_table'"
+            )
+            result = cursor.fetchone()
+        assert result is None
+
+    def test_drop_non_existent_table(self, db_mock) -> None:
+        """Test dropping a table that doesn't exist."""
+
+        class NonExistentModel(BaseDBModel):
+            name: str
+
+            class Meta:
+                table_name = "non_existent_table"
+
+        # This should not raise an exception due to 'IF EXISTS' in the SQL
+        db_mock.drop_table(NonExistentModel)
+
+    def test_drop_table_with_data(self, db_mock) -> None:
+        """Test dropping a table that contains data."""
+
+        class DataModel(BaseDBModel):
+            name: str
+
+            class Meta:
+                table_name = "data_table"
+
+        db_mock.create_table(DataModel)
+        db_mock.insert(DataModel(name="Test Data"))
+
+        db_mock.drop_table(DataModel)
+
+        # Verify the table no longer exists
+        with db_mock.connect() as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' "
+                "AND name='data_table'"
+            )
+            result = cursor.fetchone()
+        assert result is None
+
+    def test_drop_table_error(self, db_mock: SqliterDB, mocker) -> None:
+        """Test error handling when dropping a table fails."""
+
+        class ErrorModel(BaseDBModel):
+            name: str
+
+            class Meta:
+                table_name = "error_table"
+
+        mocker.patch.object(db_mock, "connect", side_effect=sqlite3.Error)
+
+        with pytest.raises(TableDeletionError) as exc_info:
+            db_mock.drop_table(ErrorModel)
+
+        assert "Failed to delete the table: 'error_table'" in str(
+            exc_info.value
+        )
+
+    def test_drop_table_auto_commit(self, db_mock, mocker) -> None:
+        """Test auto-commit behavior when dropping a table."""
+
+        class CommitModel(BaseDBModel):
+            name: str
+
+            class Meta:
+                table_name = "commit_table"
+
+        mock_commit = mocker.patch.object(db_mock, "commit")
+        db_mock.drop_table(CommitModel)
+        mock_commit.assert_called_once()


### PR DESCRIPTION
Add and test a `drop_table` method on SqliterDB. As the name suggests, it will drop the specified table.