### PR TITLE
Add `reset=` to SqliterDB(), to drop all existing tables

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2,15 +2,11 @@
 
 ## General Plans and Ideas
 
-- add an option to the SQLiter constructor to delete the database file if it
-  already exists. Default to False.
 - add attributes to the BaseDBModel to read the table-name, file-name, is-memory
   etc.
 - add an 'execute' method to the main class to allow executing arbitrary SQL
   queries which can be chained to the 'find_first' etc methods or just used
   directly.
-- add a method to drop the entire database easiest way is prob to just delete
-  and recreate the database file.
 - add an 'exists_ok' (default True) parameter to the 'create_table' method so it
   will raise an exception if the table already exists and this is set to False.
 - add a `rollback` method to the main class to allow manual rollbacks.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -91,6 +91,18 @@ exception will be raised.
 > db = SqliterDB(":memory:")
 > ```
 
+#### Resetting the Database
+
+If you want to reset the database when you create the SqliterDB object, you can
+pass `reset=True`:
+
+```python
+db = SqliterDB("your_database.db", reset=True)
+```
+
+This will effectively drop all user tables from the database. The file itself is
+not deleted, only the tables are dropped.
+
 ### Creating Tables
 
 ```python

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,6 +119,9 @@ target-version = "py39" # minimum python version supported
 indent-style = "space"
 quote-style = "double"
 
+[tool.ruff.lint.pylint]
+max-args = 6
+
 [tool.ruff.lint.pep8-naming]
 classmethod-decorators = ["pydantic.validator", "pydantic.root_validator"]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -194,3 +194,9 @@ def db_mock_complex_debug() -> SqliterDB:
         )
     )
     return db
+
+
+@pytest.fixture
+def temp_db_path(tmp_path) -> str:
+    """Fixture to create a temporary database file path."""
+    return str(tmp_path / "test_db.sqlite")

--- a/tests/test_debug_logging.py
+++ b/tests/test_debug_logging.py
@@ -256,3 +256,10 @@ class TestDebugLogging:
         assert (
             "Executing SQL: DROP TABLE IF EXISTS complex_model" in caplog.text
         )
+
+    def test_reset_database_debug_logging(self, temp_db_path, caplog) -> None:
+        """Test that resetting the database logs debug information."""
+        with caplog.at_level(logging.DEBUG):
+            SqliterDB(temp_db_path, reset=True, debug=True)
+
+        assert "Database reset: 0 user-created tables dropped." in caplog.text


### PR DESCRIPTION
add `reset=True` (default False) to the SqliterDB class which will drop all user tables from the database. The file itself is not deleted.

