### PR TITLE
Add `exists_ok` and `force` flags to `create_table`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 **New Features**
 
+- Add `reset=` to SqliterDB(), to drop all existing tables ([#33](https://github.com/seapagan/sqliter-py/pull/33)) by [seapagan](https://github.com/seapagan)
+- Order by primary key if no field specified to `order()` ([#32](https://github.com/seapagan/sqliter-py/pull/32)) by [seapagan](https://github.com/seapagan)
 - Add `drop_table` method ([#31](https://github.com/seapagan/sqliter-py/pull/31)) by [seapagan](https://github.com/seapagan)
 - Add debug logging option ([#29](https://github.com/seapagan/sqliter-py/pull/29)) by [seapagan](https://github.com/seapagan)
 - Create relevant database fields depending on the Model types ([#27](https://github.com/seapagan/sqliter-py/pull/27)) by [seapagan](https://github.com/seapagan)

--- a/TODO.md
+++ b/TODO.md
@@ -7,8 +7,6 @@
 - add an 'execute' method to the main class to allow executing arbitrary SQL
   queries which can be chained to the 'find_first' etc methods or just used
   directly.
-- add an 'exists_ok' (default True) parameter to the 'create_table' method so it
-  will raise an exception if the table already exists and this is set to False.
 - add a `rollback` method to the main class to allow manual rollbacks.
 - allow adding multiple indexes to each table as well as the primary key.
 - allow adding foreign keys and relationships to each table.
@@ -20,6 +18,11 @@
   need to be stored as a JSON string or pickled in the database (the latter
   would be more versatile). Also support `date` which can be either stored as a
   string or more useful as a Unix timestamp in an integer field.
+
+## Housekeeping
+
+- Tidy up the test suite - remove any duplicates, sort them into logical files
+  (many already are), try to reduce and centralize fixtures.
 
 ## Potential Filter Additions
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -113,6 +113,16 @@ db.create_table(User)
 >
 > The Table is created **regardless** of the `auto_commit` setting.
 
+By default, if the table already exists, it will not be created again and no
+error will be raised. If you want to raise an exception if the table already
+exists, you can set `exists_ok=False`:
+
+```python
+db.create_table(User, exists_ok=False)
+```
+
+This will raise a `TableCreationError` if the table already exists.
+
 ### Dropping Tables
 
 ```python

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -123,6 +123,15 @@ db.create_table(User, exists_ok=False)
 
 This will raise a `TableCreationError` if the table already exists.
 
+There is a complementary flag `force=True` which will drop the table if it
+exists and then recreate it:
+
+```python
+db.create_table(User, force=True)
+```
+
+This defaults to `False`.
+
 ### Dropping Tables
 
 ```python

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -124,7 +124,8 @@ db.create_table(User, exists_ok=False)
 This will raise a `TableCreationError` if the table already exists.
 
 There is a complementary flag `force=True` which will drop the table if it
-exists and then recreate it:
+exists and then recreate it. This may be useful if you are changing the table
+structure:
 
 ```python
 db.create_table(User, force=True)

--- a/sqliter/exceptions.py
+++ b/sqliter/exceptions.py
@@ -139,3 +139,9 @@ class TableDeletionError(SqliterError):
     """Raised when a table cannot be deleted from the database."""
 
     message_template = "Failed to delete the table: '{}'"
+
+
+class SqlExecutionError(SqliterError):
+    """Raised when an SQL execution fails."""
+
+    message_template = "Failed to execute SQL: '{}'"

--- a/sqliter/sqliter.py
+++ b/sqliter/sqliter.py
@@ -200,11 +200,15 @@ class SqliterDB:
         if self.conn:
             self.conn.commit()
 
-    def create_table(self, model_class: type[BaseDBModel]) -> None:
+    def create_table(
+        self, model_class: type[BaseDBModel], *, exists_ok: bool = True
+    ) -> None:
         """Create a table in the database based on the given model class.
 
         Args:
             model_class: The Pydantic model class representing the table.
+            exists_ok: If True, do not raise an error if the table already
+                exists. Default is True which is the original behavior.
 
         Raises:
             TableCreationError: If there's an error creating the table.
@@ -237,8 +241,13 @@ class SqliterDB:
                 sqlite_type = infer_sqlite_type(field_info.annotation)
                 fields.append(f"{field_name} {sqlite_type}")
 
+        if exists_ok:
+            create_str = "CREATE TABLE IF NOT EXISTS"
+        else:
+            create_str = "CREATE TABLE"
+
         create_table_sql = f"""
-        CREATE TABLE IF NOT EXISTS {table_name} (
+        {create_str} {table_name} (
             {", ".join(fields)}
         )
         """

--- a/sqliter/sqliter.py
+++ b/sqliter/sqliter.py
@@ -21,6 +21,7 @@ from sqliter.exceptions import (
     RecordInsertionError,
     RecordNotFoundError,
     RecordUpdateError,
+    SqlExecutionError,
     TableCreationError,
     TableDeletionError,
 )
@@ -273,6 +274,14 @@ class SqliterDB:
             raise TableCreationError(table_name) from exc
 
     def _execute_sql(self, sql: str) -> None:
+        """Execute an SQL statement.
+
+        Args:
+            sql: The SQL statement to execute.
+
+        Raises:
+            SqlExecutionError: If the SQL execution fails.
+        """
         if self.debug:
             self._log_sql(sql, [])
 
@@ -281,8 +290,8 @@ class SqliterDB:
                 cursor = conn.cursor()
                 cursor.execute(sql)
                 conn.commit()
-        except sqlite3.Error as exc:
-            raise TableCreationError(sql) from exc
+        except (sqlite3.Error, sqlite3.Warning) as exc:
+            raise SqlExecutionError(sql) from exc
 
     def drop_table(self, model_class: type[BaseDBModel]) -> None:
         """Drop the table associated with the given model class.

--- a/tests/test_execute_sql.py
+++ b/tests/test_execute_sql.py
@@ -1,0 +1,92 @@
+"""Test class for the '_execute_sql' method."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from sqliter import SqliterDB
+from sqliter.exceptions import TableCreationError
+
+
+class TestExecuteSQL:
+    """Test the _execute_sql method of the SqliterDB class."""
+
+    def setup_method(self) -> None:
+        """Setup the tests."""
+        self.db = SqliterDB(":memory:")
+
+    def teardown_method(self) -> None:
+        """Teardown the tests."""
+        self.db.close()
+
+    def test_execute_sql_success(self) -> None:
+        """Test successful SQL execution."""
+        sql = "CREATE TABLE test (id INTEGER PRIMARY KEY, name TEXT)"
+        self.db._execute_sql(sql)
+
+        # Verify the table was created
+        with self.db.connect() as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' "
+                "AND name='test'"
+            )
+            result = cursor.fetchone()
+        assert result is not None
+        assert result[0] == "test"
+
+    def test_execute_sql_error(self) -> None:
+        """Test SQL execution with an error."""
+        # Missing closing parenthesis...
+        invalid_sql = "CREATE TABLE test (id INTEGER PRIMARY KEY, name TEXT"
+        with pytest.raises(TableCreationError):
+            self.db._execute_sql(invalid_sql)
+
+    @patch("sqliter.sqliter.SqliterDB._log_sql")
+    def test_execute_sql_debug_logging(self, mock_log_sql: MagicMock) -> None:
+        """Test that SQL is logged when debug is True."""
+        self.db.debug = True
+        sql = "CREATE TABLE test_log (id INTEGER PRIMARY KEY)"
+        self.db._execute_sql(sql)
+        mock_log_sql.assert_called_once_with(sql, [])
+
+    def test_execute_sql_commit(self) -> None:
+        """Test that changes are committed after SQL execution."""
+        self.db.auto_commit = False  # Disable auto-commit to test manual commit
+        sql = "CREATE TABLE test_commit (id INTEGER PRIMARY KEY)"
+        self.db._execute_sql(sql)
+
+        # Verify the table exists even with auto_commit off
+        with self.db.connect() as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' "
+                "AND name='test_commit'"
+            )
+            result = cursor.fetchone()
+        assert result is not None
+        assert result[0] == "test_commit"
+
+    def test_execute_sql_multiple_statements(self) -> None:
+        """Test executing multiple SQL statements raises an error."""
+        sql = """
+        CREATE TABLE test_multi (id INTEGER PRIMARY KEY, name TEXT);
+        INSERT INTO test_multi (name) VALUES ('test');
+        """
+        with pytest.raises(TableCreationError) as exc_info:
+            self.db._execute_sql(sql)
+
+        assert "You can only execute one statement at a time." in str(
+            exc_info.value
+        )
+
+    def test_execute_sql_with_parameters(self) -> None:
+        """Test that _execute_sql doesn't support parameters directly."""
+        self.db._execute_sql(
+            "CREATE TABLE test_params (id INTEGER PRIMARY KEY, name TEXT)"
+        )
+        sql = "INSERT INTO test_params (name) VALUES (?)"
+        with pytest.raises(TableCreationError):
+            self.db._execute_sql(
+                sql
+            )  # This should fail as _execute_sql doesn't support parameters

--- a/tests/test_execute_sql.py
+++ b/tests/test_execute_sql.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from sqliter import SqliterDB
-from sqliter.exceptions import TableCreationError
+from sqliter.exceptions import SqlExecutionError
 
 
 class TestExecuteSQL:
@@ -39,7 +39,7 @@ class TestExecuteSQL:
         """Test SQL execution with an error."""
         # Missing closing parenthesis...
         invalid_sql = "CREATE TABLE test (id INTEGER PRIMARY KEY, name TEXT"
-        with pytest.raises(TableCreationError):
+        with pytest.raises(SqlExecutionError):
             self.db._execute_sql(invalid_sql)
 
     @patch("sqliter.sqliter.SqliterDB._log_sql")
@@ -73,7 +73,7 @@ class TestExecuteSQL:
         CREATE TABLE test_multi (id INTEGER PRIMARY KEY, name TEXT);
         INSERT INTO test_multi (name) VALUES ('test');
         """
-        with pytest.raises(TableCreationError) as exc_info:
+        with pytest.raises(SqlExecutionError) as exc_info:
             self.db._execute_sql(sql)
 
         assert "You can only execute one statement at a time." in str(
@@ -86,7 +86,7 @@ class TestExecuteSQL:
             "CREATE TABLE test_params (id INTEGER PRIMARY KEY, name TEXT)"
         )
         sql = "INSERT INTO test_params (name) VALUES (?)"
-        with pytest.raises(TableCreationError):
+        with pytest.raises(SqlExecutionError):
             self.db._execute_sql(
                 sql
             )  # This should fail as _execute_sql doesn't support parameters

--- a/tests/test_sqliter.py
+++ b/tests/test_sqliter.py
@@ -1,7 +1,5 @@
 """Test suite for the 'sqliter' library."""
 
-import sqlite3
-
 import pytest
 
 from sqliter import SqliterDB


### PR DESCRIPTION
- add `exists=` flag to the `create_table` method.
	- this defaults to `True` and will silently ignore a table if it already exists. If you set to `False`, it will instead raise a `TableCreationError`
- add `force=` flag to the `create_table` method.
	- this defaults to `False`. If set to `True	`, it will explicitly drop then re-create the table.