### PR TITLE
Always create a `pk` primary auto-incrementing key

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,6 +30,8 @@ repos:
     hooks:
       - id: mypy
         name: "run mypy"
+        additional_dependencies:
+          - pydantic
 
   - repo: https://github.com/astral-sh/uv-pre-commit
     # uv version.

--- a/README.md
+++ b/README.md
@@ -125,8 +125,8 @@ for user in results:
     print(f"User: {user.name}, Age: {user.age}")
 
 # Update a record
-user.age = 31
-db.update(user)
+new_user.age = 31
+db.update(new_user)
 
 # Delete a record
 db.delete(User, new_user.pk)

--- a/README.md
+++ b/README.md
@@ -24,7 +24,10 @@ Website](https://sqliter.grantramsay.dev)
 
 > [!CAUTION]
 > This project is still in the early stages of development and is lacking some
-> planned functionality. Please use with caution.
+> planned functionality. Please use with caution - Classes and methods may
+> change until a stable release is made. I'll try to keep this to an absolute
+> minimum and the releases and documentation will be very clear about any
+> breaking changes.
 >
 > Also, structures like `list`, `dict`, `set` etc are not supported **at this
 > time** as field types, since SQLite does not have a native column type for
@@ -45,7 +48,7 @@ Website](https://sqliter.grantramsay.dev)
 
 - Table creation based on Pydantic models
 - CRUD operations (Create, Read, Update, Delete)
-- Basic query building with filtering, ordering, and pagination
+- Chained Query building with filtering, ordering, and pagination
 - Transaction support
 - Custom exceptions for better error handling
 - Full type hinting and type checking
@@ -114,7 +117,7 @@ db.create_table(User)
 
 # Insert a record
 user = User(name="John Doe", age=30)
-new_record = db.insert(user)
+new_user = db.insert(user)
 
 # Query records
 results = db.select(User).filter(name="John Doe").fetch_all()
@@ -123,10 +126,10 @@ for user in results:
 
 # Update a record
 user.age = 31
-db.update(User, new_record)
+db.update(user)
 
 # Delete a record
-db.delete(User, new_record.pk)
+db.delete(User, new_user.pk)
 ```
 
 See the [Usage](https://sqliter.grantramsay.dev/usage) section of the documentation

--- a/demo.py
+++ b/demo.py
@@ -64,7 +64,7 @@ def main() -> None:
         )
         try:
             db.insert(user1)
-            user2_id = db.insert(user2)
+            user2_instance = db.insert(user2)
             db.insert(user3)
         except RecordInsertionError as exc:
             logging.error(exc)  # noqa: TRY400
@@ -81,11 +81,11 @@ def main() -> None:
         )
         logging.info(all_reversed)
 
-        if user2_id is None:
+        if user2_instance is None:
             logging.error("User2 ID not found.")
         else:
-            fetched_user = db.get(UserModel, user2_id)
-            logging.info(fetched_user)
+            fetched_user = db.get(UserModel, user2_instance.pk)
+            logging.info("Fetched (%s)", fetched_user)
 
         count = db.select(UserModel).count()
         logging.info("Total Users: %s", count)

--- a/demo.py
+++ b/demo.py
@@ -81,8 +81,11 @@ def main() -> None:
         )
         logging.info(all_reversed)
 
-        fetched_user = db.get(UserModel, user2_id)
-        logging.info(fetched_user)
+        if user2_id is None:
+            logging.error("User2 ID not found.")
+        else:
+            fetched_user = db.get(UserModel, user2_id)
+            logging.info(fetched_user)
 
         count = db.select(UserModel).count()
         logging.info("Total Users: %s", count)

--- a/demo.py
+++ b/demo.py
@@ -41,7 +41,9 @@ def main() -> None:
         level=logging.DEBUG, format="%(levelname)-8s%(message)s"
     )
 
-    db = SqliterDB(memory=True, auto_commit=True, debug=True)
+    db = SqliterDB(
+        "demo.db", memory=False, auto_commit=True, debug=True, reset=True
+    )
     with db:
         db.create_table(UserModel)  # Create the users table
         user1 = UserModel(
@@ -62,7 +64,7 @@ def main() -> None:
         )
         try:
             db.insert(user1)
-            db.insert(user2)
+            user2_id = db.insert(user2)
             db.insert(user3)
         except RecordInsertionError as exc:
             logging.error(exc)  # noqa: TRY400
@@ -79,7 +81,7 @@ def main() -> None:
         )
         logging.info(all_reversed)
 
-        fetched_user = db.get(UserModel, "jdoe2")
+        fetched_user = db.get(UserModel, user2_id)
         logging.info(fetched_user)
 
         count = db.select(UserModel).count()

--- a/docs/guide/data-ops.md
+++ b/docs/guide/data-ops.md
@@ -56,12 +56,12 @@ See [Filtering Results](filtering.md) for more advanced filtering options.
 ## Updating Records
 
 You can update records in the database by modifying the fields of the model
-instance and then calling the `update()` method. You need to pass the model
-class and the instance to the method:
+instance and then calling the `update()` method. You just pass the model
+instance to the method:
 
 ```python
 user.age = 26
-db.update(User, user)
+db.update(user)
 ```
 
 ## Deleting Records

--- a/docs/guide/data-ops.md
+++ b/docs/guide/data-ops.md
@@ -8,7 +8,16 @@ into the correct table:
 
 ```python
 user = User(name="Jane Doe", age=25, email="jane@example.com")
-db.insert(user)
+result = db.insert(user)
+```
+
+The `result` variable will contain a new instance of the model, with the primary
+key value set to the newly-created primary key in the database. You should use
+this instance to access the primary key value and other fields:
+
+```python
+print(f"New record inserted with primary key: {result.pk}")
+print(f"Name: {result.name}, Age: {result.age}, Email: {result.email}")
 ```
 
 > [!IMPORTANT]
@@ -46,15 +55,22 @@ See [Filtering Results](filtering.md) for more advanced filtering options.
 
 ## Updating Records
 
+You can update records in the database by modifying the fields of the model
+instance and then calling the `update()` method. You need to pass the model
+class and the instance to the method:
+
 ```python
 user.age = 26
-db.update(user)
+db.update(User, user)
 ```
 
 ## Deleting Records
 
+To delete a record from the database, you need to pass the model class and the
+primary key value of the record you want to delete:
+
 ```python
-db.delete(User, "Jane Doe")
+db.delete(User, user.pk)
 ```
 
 ## Commit your changes

--- a/docs/guide/filtering.md
+++ b/docs/guide/filtering.md
@@ -8,6 +8,17 @@ records, and can be combined with other methods like `order()`, `limit()`, and
 result = db.select(User).filter(age__lte=30).limit(10).fetch_all()
 ```
 
+It is possible to both add multiple filters in the same call, and to chain
+multiple filter calls together:
+
+```python
+result = db.select(User).filter(age__gte=20, age__lte=30).fetch_all()
+```
+
+```python
+result = db.select(User).filter(age__gte=20).filter(age__lte=30).fetch_all()
+```
+
 ## Basic Filters
 
 - `__eq`: Equal to (default if no operator is specified)

--- a/docs/guide/guide.md
+++ b/docs/guide/guide.md
@@ -113,12 +113,11 @@ returned.
 ## Updating Records
 
 Records can be updated seamlessly. Simply modify the fields of the model
-instance and call the `update()` method, passing the model class and the updated
-instance:
+instance and pass that to the `update()` method:
 
 ```python
 user.age = 31
-db.update(User, user)
+db.update(user)
 ```
 
 ## Deleting Records

--- a/docs/guide/guide.md
+++ b/docs/guide/guide.md
@@ -41,8 +41,11 @@ Inserting records is straightforward with SQLiter:
 
 ```python
 user = User(name="John Doe", age=30, email="john@example.com")
-db.insert(user)
+new_record = db.insert(user)
 ```
+
+If successful, `new_record` will contain a model the same as was passed to it,
+but including the newly-created primary key value.
 
 ## Basic Queries
 
@@ -109,20 +112,33 @@ returned.
 
 ## Updating Records
 
-Records can be updated seamlessly:
+Records can be updated seamlessly. Simply modify the fields of the model
+instance and call the `update()` method, passing the model class and the updated
+instance:
 
 ```python
 user.age = 31
-db.update(user)
+db.update(User, user)
 ```
 
 ## Deleting Records
 
-Deleting records is simple as well:
+Deleting records is simple as well. You just need to pass the Model that defines
+your table and the primary key value of the record you want to delete:
 
 ```python
-db.delete(User, "John Doe")
+db.delete(User, 1)
 ```
+
+> [!NOTE]
+>
+> You can get the primary key value from the record or model instance itself,
+> e.g., `new_record.pk` and pass that as the second argument to the `delete()`
+> method:
+>
+> ```python
+> db.delete(User, new_record.pk)
+> ```
 
 ## Advanced Query Features
 

--- a/docs/guide/models.md
+++ b/docs/guide/models.md
@@ -1,8 +1,40 @@
-# Defining Models
+# Models
 
-Models in SQLiter use Pydantic to encapsulate the logic. All models should
-inherit from SQLiter's `BaseDBModel`. You can define your
-models like this:
+Each individual table in your database should be represented by a model. This
+model should inherit from `BaseDBModel` and define the fields that should be
+stored in the table. Under the hood, the model is a Pydantic model, so you can
+use all the features of Pydantic models, such as default values, type hints, and
+validation.
+
+## Defining Models
+
+Models are defined like this:
+
+```python
+from sqliter.model import BaseDBModel
+
+class User(BaseDBModel):
+    name: str
+    age: int
+    email: str
+```
+
+You can create as many Models as you need, each representing a different table
+in your database. The fields in the model will be used to create the columns in
+the table.
+
+> [!IMPORTANT]
+>
+> - Type-hints are **REQUIRED** for each field in the model.
+> - The Model **automatically** creates an **auto-incrementing integer primary
+> key** for each table called `pk`, you do not need to define it yourself.
+
+### Custom Table Name
+
+By default, the table name will be the same as the model name, converted to
+'snake_case' and pluralized (e.g., `User` -> `users`). Also, any 'Model' suffix
+will be removed (e.g., `UserModel` -> `users`). To override this behavior, you
+can specify the `table_name` in the `Meta` class manually as below:
 
 ```python
 from sqliter.model import BaseDBModel
@@ -13,21 +45,8 @@ class User(BaseDBModel):
     email: str
 
     class Meta:
-        table_name = "users"
-        primary_key = "name"  # Default is "id"
-        create_pk = False  # disable auto-creating an incrementing primary key - default is True
+        table_name = "people"
 ```
-
-For a standard database with an auto-incrementing integer `id` primary key, you
-do not need to specify the `primary_key` or `create_pk` fields. If you want to
-specify a different primary key field name, you can do so using the
-`primary_key` field in the `Meta` class.
-
-If `table_name` is not specified, the table name will be the same as the model
-name, converted to 'snake_case' and pluralized (e.g., `User` -> `users`). Also,
-any 'Model' suffix will be removed (e.g., `UserModel` -> `users`). To override
-this behavior, you can specify the `table_name` in the `Meta` class manually as
-above.
 
 > [!NOTE]
 >
@@ -36,3 +55,27 @@ above.
 > you need more advanced pluralization, you can install the `extras` package as
 > mentioned in the [installation](../installation.md#optional-dependencies). Of
 > course, you can always specify the `table_name` manually in this case!
+
+## Model Classmethods
+
+There are 2 useful methods you can call on your models. Note that they are
+**Class Methods** so should be called on the Model class itself, not an
+instance of the model:
+
+### `get_table_name()`
+
+This method returns the actual table name for the model either specified or
+automatically generated. This is useful if you need to do any raw SQL queries.
+
+```python
+table_name = User.get_table_name()
+```
+
+### `get_primary_key()`
+
+This simply returns the name of the primary key for that table. At the moment,
+this will always return the string `pk` but this may change in the future.
+
+```python
+primary_key = User.get_primary_key()
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,7 +22,10 @@ database-like format without needing to learn SQL or use a full ORM.
 
 > [!CAUTION]
 > This project is still in the early stages of development and is lacking some
-> planned functionality. Please use with caution.
+> planned functionality. Please use with caution - Classes and methods may
+> change until a stable release is made. I'll try to keep this to an absolute
+> minimum and the releases and documentation will be very clear about any
+> breaking changes.
 >
 > Also, structures like `list`, `dict`, `set` etc are not supported **at this
 > time** as field types, since SQLite does not have a native column type for
@@ -36,7 +39,7 @@ database-like format without needing to learn SQL or use a full ORM.
 
 - Table creation based on Pydantic models
 - CRUD operations (Create, Read, Update, Delete)
-- Basic query building with filtering, ordering, and pagination
+- Chained Query building with filtering, ordering, and pagination
 - Transaction support
 - Custom exceptions for better error handling
 - Full type hinting and type checking

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -26,7 +26,7 @@ db.create_table(User)
 
 # Insert a record
 user = User(name="John Doe", age=30)
-db.insert(user)
+new_record = db.insert(user)
 
 # Query records
 results = db.select(User).filter(name="John Doe").fetch_all()
@@ -35,10 +35,14 @@ for user in results:
 
 # Update a record
 user.age = 31
-db.update(user)
+db.update(User, user)
+
+results = db.select(User).filter(name="John Doe").fetch_one()
+
+print("Updated age:", results.age)
 
 # Delete a record
-db.delete(User, "John Doe")
+db.delete(User, new_record.pk)
 ```
 
 See the [Guide](guide/guide.md) for more detailed information on how to use `SQLiter`.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -26,7 +26,7 @@ db.create_table(User)
 
 # Insert a record
 user = User(name="John Doe", age=30)
-new_record = db.insert(user)
+new_user = db.insert(user)
 
 # Query records
 results = db.select(User).filter(name="John Doe").fetch_all()
@@ -34,15 +34,15 @@ for user in results:
     print(f"User: {user.name}, Age: {user.age}, Admin: {user.admin}")
 
 # Update a record
-user.age = 31
-db.update(User, user)
+new_user.age = 31
+db.update(new_user)
 
 results = db.select(User).filter(name="John Doe").fetch_one()
 
 print("Updated age:", results.age)
 
 # Delete a record
-db.delete(User, new_record.pk)
+db.delete(User, new_user.pk)
 ```
 
 See the [Guide](guide/guide.md) for more detailed information on how to use `SQLiter`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -12,6 +12,7 @@ theme:
     - navigation.tabs
     - navigation.sections
     - navigation.indexes
+    - content.code.copy
 
 extra:
   social:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -144,9 +144,10 @@ known-first-party = ["sqliter"]
 keep-runtime-typing = true
 
 [tool.mypy]
+plugins = ["pydantic.mypy"]
+
 python_version = "3.9"
 exclude = ["docs"]
-
 [[tool.mypy.overrides]]
 disable_error_code = ["method-assign", "no-untyped-def", "attr-defined"]
 module = "tests.*"

--- a/sqliter/exceptions.py
+++ b/sqliter/exceptions.py
@@ -114,7 +114,7 @@ class RecordUpdateError(SqliterError):
 class RecordNotFoundError(SqliterError):
     """Exception raised when a requested record is not found in the database."""
 
-    message_template = "Failed to find a record for key '{}' "
+    message_template = "Failed to find that record in the table (key '{}') "
 
 
 class RecordFetchError(SqliterError):

--- a/sqliter/model/model.py
+++ b/sqliter/model/model.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import re
 from typing import Any, Optional, TypeVar, Union, get_args, get_origin
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 T = TypeVar("T", bound="BaseDBModel")
 
@@ -27,6 +27,10 @@ class BaseDBModel(BaseModel):
     This should not be used directly, but should be inherited by subclasses
     representing database models.
     """
+
+    pk: Optional[int] = Field(
+        None, description="The mandatory primary key of the table."
+    )
 
     model_config = ConfigDict(
         extra="ignore",
@@ -44,10 +48,6 @@ class BaseDBModel(BaseModel):
             table_name (Optional[str]): The name of the database table.
         """
 
-        create_pk: bool = (
-            True  # Whether to create an auto-increment primary key
-        )
-        primary_key: str = "id"  # Default primary key name
         table_name: Optional[str] = (
             None  # Table name, defaults to class name if not set
         )
@@ -127,18 +127,10 @@ class BaseDBModel(BaseModel):
 
     @classmethod
     def get_primary_key(cls) -> str:
-        """Get the primary key field name for the model.
-
-        Returns:
-            The name of the primary key field.
-        """
-        return getattr(cls.Meta, "primary_key", "id")
+        """Returns the mandatory primary key, always 'pk'."""
+        return "pk"
 
     @classmethod
     def should_create_pk(cls) -> bool:
-        """Determine if a primary key should be automatically created.
-
-        Returns:
-            True if a primary key should be created, False otherwise.
-        """
-        return getattr(cls.Meta, "create_pk", True)
+        """Returns True since the primary key is always created."""
+        return True

--- a/sqliter/model/model.py
+++ b/sqliter/model/model.py
@@ -10,7 +10,7 @@ in SQLiter applications.
 from __future__ import annotations
 
 import re
-from typing import Any, Optional, TypeVar, Union, get_args, get_origin
+from typing import Any, Optional, TypeVar, Union, cast, get_args, get_origin
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -87,7 +87,7 @@ class BaseDBModel(BaseModel):
                 else:
                     converted_obj[field_name] = field_type(value)
 
-        return cls.model_construct(**converted_obj)
+        return cast(T, cls.model_construct(**converted_obj))
 
     @classmethod
     def get_table_name(cls) -> str:

--- a/sqliter/model/model.py
+++ b/sqliter/model/model.py
@@ -28,9 +28,7 @@ class BaseDBModel(BaseModel):
     representing database models.
     """
 
-    pk: Optional[int] = Field(
-        None, description="The mandatory primary key of the table."
-    )
+    pk: int = Field(0, description="The mandatory primary key of the table.")
 
     model_config = ConfigDict(
         extra="ignore",

--- a/sqliter/query/query.py
+++ b/sqliter/query/query.py
@@ -184,7 +184,7 @@ class QueryBuilder:
             self._fields = list(all_fields - set(fields))
 
             # Explicit check: raise an error if no fields remain
-            if not self._fields:
+            if self._fields == ["pk"]:
                 err = "Exclusion results in no fields being selected."
                 raise ValueError(err)
 

--- a/sqliter/query/query.py
+++ b/sqliter/query/query.py
@@ -145,6 +145,8 @@ class QueryBuilder:
             The QueryBuilder instance for method chaining.
         """
         if fields:
+            if "pk" not in fields:
+                fields.append("pk")
             self._fields = fields
             self._validate_fields()
         return self
@@ -164,6 +166,9 @@ class QueryBuilder:
                 invalid fields are specified.
         """
         if fields:
+            if "pk" in fields:
+                err = "The primary key 'pk' cannot be excluded."
+                raise ValueError(err)
             all_fields = set(self.model_class.model_fields.keys())
 
             # Check for invalid fields before subtraction
@@ -208,7 +213,7 @@ class QueryBuilder:
             raise ValueError(err)
 
         # Set self._fields to just the single field
-        self._fields = [field]
+        self._fields = [field, "pk"]
         return self
 
     def _get_operator_handler(
@@ -527,6 +532,8 @@ class QueryBuilder:
         if count_only:
             fields = "COUNT(*)"
         elif self._fields:
+            if "pk" not in self._fields:
+                self._fields.append("pk")
             fields = ", ".join(f'"{field}"' for field in self._fields)
         else:
             fields = ", ".join(

--- a/sqliter/sqliter.py
+++ b/sqliter/sqliter.py
@@ -330,7 +330,8 @@ class SqliterDB:
         data = model_instance.model_dump()
         # remove the primary key field if it exists, otherwise we'll get
         # TypeErrors as multiple primary keys will exist
-        data.pop("pk")
+        if data.get("pk", None) == 0:
+            data.pop("pk")
 
         fields = ", ".join(data.keys())
         placeholders = ", ".join(
@@ -352,6 +353,7 @@ class SqliterDB:
         except sqlite3.Error as exc:
             raise RecordInsertionError(table_name) from exc
         else:
+            data.pop("pk", None)
             return model_class(pk=cursor.lastrowid, **data)
 
     def get(

--- a/sqliter/sqliter.py
+++ b/sqliter/sqliter.py
@@ -397,8 +397,8 @@ class SqliterDB:
             model_instance: An instance of a Pydantic model to be updated.
 
         Raises:
-            RecordUpdateError: If there's an error updating the record.
-            RecordNotFoundError: If the record to update is not found.
+            RecordUpdateError: If there's an error updating the record or if it
+            is not found.
         """
         model_class = type(model_instance)
         table_name = model_class.get_table_name()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,8 +39,6 @@ class ExampleModel(BaseDBModel):
     class Meta:
         """Configuration for the model."""
 
-        create_pk: bool = False
-        primary_key: str = "slug"
         table_name: str = "test_table"
 
 
@@ -53,9 +51,7 @@ class PersonModel(BaseDBModel):
     class Meta:
         """Configuration for the model."""
 
-        create_pk = False
         table_name = "person_table"
-        primary_key = "name"
 
 
 class DetailedPersonModel(BaseDBModel):
@@ -72,14 +68,11 @@ class DetailedPersonModel(BaseDBModel):
         """Configuration for the model."""
 
         table_name = "detailed_person_table"
-        primary_key = "name"
-        create_pk = False
 
 
 class ComplexModel(BaseDBModel):
     """Model to test complex field types."""
 
-    id: int
     name: str
     age: float
     is_active: bool
@@ -90,8 +83,6 @@ class ComplexModel(BaseDBModel):
         """Configuration for the model."""
 
         table_name = "complex_model"
-        primary_key = "id"
-        create_pk = False
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from contextlib import contextmanager
 from typing import TYPE_CHECKING, Any, Optional, Union
 
@@ -14,6 +15,12 @@ if TYPE_CHECKING:
     from collections.abc import Generator
 
 memory_db = ":memory:"
+
+
+@pytest.hookimpl(tryfirst=True)
+def pytest_configure(config) -> None:
+    """Clear the screen before running tests."""
+    os.system("cls" if os.name == "nt" else "clear")  # noqa: S605
 
 
 @contextmanager

--- a/tests/test_debug_logging.py
+++ b/tests/test_debug_logging.py
@@ -39,7 +39,7 @@ class TestDebugLogging:
 
         # Assert the SQL query was printed
         assert (
-            'Executing SQL: SELECT "id", "name", "age", "is_active", "score", '
+            'Executing SQL: SELECT "pk", "name", "age", "is_active", "score", '
             '"nullable_field" FROM "complex_model" WHERE age = 30.5'
             in caplog.text
         )
@@ -55,7 +55,7 @@ class TestDebugLogging:
 
         # Assert the SQL query was printed with the string properly quoted
         assert (
-            'Executing SQL: SELECT "id", "name", "age", "is_active", "score", '
+            'Executing SQL: SELECT "pk", "name", "age", "is_active", "score", '
             '"nullable_field" FROM "complex_model" WHERE name = \'Alice\''
             in caplog.text
         )
@@ -71,7 +71,7 @@ class TestDebugLogging:
 
         # Assert the SQL query was printed with multiple conditions
         assert (
-            'Executing SQL: SELECT "id", "name", "age", "is_active", "score", '
+            'Executing SQL: SELECT "pk", "name", "age", "is_active", "score", '
             '"nullable_field" FROM "complex_model" WHERE name = \'Alice\' AND '
             "age = 30.5" in caplog.text
         )
@@ -87,7 +87,7 @@ class TestDebugLogging:
 
         # Assert the SQL query was printed with ORDER and LIMIT
         assert (
-            'Executing SQL: SELECT "id", "name", "age", "is_active", "score", '
+            'Executing SQL: SELECT "pk", "name", "age", "is_active", "score", '
             '"nullable_field" FROM "complex_model" ORDER BY "age" DESC LIMIT 1'
             in caplog.text
         )
@@ -99,7 +99,7 @@ class TestDebugLogging:
         with caplog.at_level(logging.DEBUG):
             db_mock_complex_debug.insert(
                 ComplexModel(
-                    id=4,
+                    pk=4,
                     name="David",
                     age=40.0,
                     is_active=True,
@@ -114,7 +114,7 @@ class TestDebugLogging:
 
         # Assert the SQL query was printed with IS NULL
         assert (
-            'Executing SQL: SELECT "id", "name", "age", "is_active", "score", '
+            'Executing SQL: SELECT "pk", "name", "age", "is_active", "score", '
             '"nullable_field" FROM "complex_model" WHERE age IS NULL'
             in caplog.text
         )
@@ -130,7 +130,8 @@ class TestDebugLogging:
 
         # Assert the SQL query only selects the 'name' field
         assert (
-            'Executing SQL: SELECT "name" FROM "complex_model"' in caplog.text
+            'Executing SQL: SELECT "name", "pk" FROM "complex_model"'
+            in caplog.text
         )
 
     def test_debug_sql_output_with_fields_multiple(
@@ -144,7 +145,7 @@ class TestDebugLogging:
 
         # Assert the SQL query only selects the 'name' and 'age' fields
         assert (
-            'Executing SQL: SELECT "name", "age" FROM "complex_model"'
+            'Executing SQL: SELECT "name", "age", "pk" FROM "complex_model"'
             in caplog.text
         )
 
@@ -159,7 +160,7 @@ class TestDebugLogging:
 
         # Assert the SQL query selects 'name' and 'score' and applies the filter
         assert (
-            'Executing SQL: SELECT "name", "score" FROM "complex_model" '
+            'Executing SQL: SELECT "name", "score", "pk" FROM "complex_model" '
             "WHERE score > 85" in caplog.text
         )
 
@@ -198,7 +199,7 @@ class TestDebugLogging:
 
         # Assert that log output was captured with the manually passed logger
         assert (
-            'Executing SQL: SELECT "id", "name", "age", "is_active", "score", '
+            'Executing SQL: SELECT "pk", "name", "age", "is_active", "score", '
             in caplog.text
         )
 
@@ -227,7 +228,7 @@ class TestDebugLogging:
 
         # Assert that the SQL query was logged despite no matching records
         assert (
-            'Executing SQL: SELECT "id", "name", "age", "is_active", "score", '
+            'Executing SQL: SELECT "pk", "name", "age", "is_active", "score", '
             '"nullable_field" FROM "complex_model" WHERE age = 100'
             in caplog.text
         )
@@ -241,7 +242,7 @@ class TestDebugLogging:
 
         # Assert that the SQL query was logged for a full table scan
         assert (
-            'Executing SQL: SELECT "id", "name", "age", "is_active", "score", '
+            'Executing SQL: SELECT "pk", "name", "age", "is_active", "score", '
             '"nullable_field" FROM "complex_model"' in caplog.text
         )
 

--- a/tests/test_execeptions.py
+++ b/tests/test_execeptions.py
@@ -99,7 +99,7 @@ class TestExceptions:
             db_mock.update(example_model)
 
         # Verify that the exception message contains the table name
-        assert "Failed to find that record in the table (key 'None')" in str(
+        assert "Failed to find that record in the table (key '0')" in str(
             exc_info.value
         )
 

--- a/tests/test_execeptions.py
+++ b/tests/test_execeptions.py
@@ -55,6 +55,7 @@ class TestExceptions:
             exc_info.value
         )
 
+    @pytest.mark.skip(reason="This is no longer a valid test case.")
     def test_insert_duplicate_primary_key(self, db_mock) -> None:
         """Test that exception raised when inserting duplicate primary key."""
         # Create a model instance with a unique primary key
@@ -98,7 +99,9 @@ class TestExceptions:
             db_mock.update(example_model)
 
         # Verify that the exception message contains the table name
-        assert "Failed to find a record for key 'test'" in str(exc_info.value)
+        assert "Failed to find that record in the table (key 'None')" in str(
+            exc_info.value
+        )
 
     def test_update_exception_error(self, db_mock, mocker) -> None:
         """Test an exception is raised when updating a record with an error."""

--- a/tests/test_execeptions.py
+++ b/tests/test_execeptions.py
@@ -55,7 +55,7 @@ class TestExceptions:
             exc_info.value
         )
 
-    @pytest.mark.skip(reason="This is no longer a valid test case.")
+    # @pytest.mark.skip(reason="This is no longer a valid test case.")
     def test_insert_duplicate_primary_key(self, db_mock) -> None:
         """Test that exception raised when inserting duplicate primary key."""
         # Create a model instance with a unique primary key
@@ -64,11 +64,11 @@ class TestExceptions:
         )
 
         # Insert the record for the first time, should succeed
-        db_mock.insert(example_model)
+        result = db_mock.insert(example_model)
 
         # Try inserting the same record again, which should raise our exception
         with pytest.raises(RecordInsertionError) as exc_info:
-            db_mock.insert(example_model)
+            db_mock.insert(result)
 
         # Verify that the exception message contains the table name
         assert "Failed to insert record into table: 'test_table'" in str(

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,0 +1,47 @@
+from typing import Optional
+
+import pytest
+
+from sqliter.model.model import BaseDBModel
+
+"""Test the Model and it's methods."""
+
+
+class TestBaseDBModel:
+    def test_should_create_pk(self) -> None:
+        """Test that 'should_create_pk' returns True."""
+        assert BaseDBModel.should_create_pk() is True
+
+    def test_get_primary_key(self) -> None:
+        """Test that 'get_primary_key' returns 'pk'."""
+        assert BaseDBModel.get_primary_key() == "pk"
+
+    def test_get_table_name_default(self) -> None:
+        """Test that 'get_table_name' returns the default table name."""
+
+        class TestModel(BaseDBModel):
+            pass
+
+        assert TestModel.get_table_name() == "tests"
+
+    def test_get_table_name_custom(self) -> None:
+        """Test that 'get_table_name' returns the custom table name."""
+
+        class TestModel(BaseDBModel):
+            class Meta:
+                table_name = "custom_table"
+
+        assert TestModel.get_table_name() == "custom_table"
+
+    def test_model_validate_partial(self) -> None:
+        """Test 'model_validate_partial' with partial data."""
+
+        class TestModel(BaseDBModel):
+            name: str
+            age: Optional[int]
+
+        data = {"name": "John"}
+        model_instance = TestModel.model_validate_partial(data)
+        assert model_instance.name == "John"
+        with pytest.raises(AttributeError):
+            _ = model_instance.age

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,13 +1,15 @@
+"""Specific tests for the Model and it's methods."""
+
 from typing import Optional
 
 import pytest
 
 from sqliter.model.model import BaseDBModel
 
-"""Test the Model and it's methods."""
-
 
 class TestBaseDBModel:
+    """Test the Model and it's methods."""
+
     def test_should_create_pk(self) -> None:
         """Test that 'should_create_pk' returns True."""
         assert BaseDBModel.should_create_pk() is True

--- a/tests/test_optional_fields_complex_model.py
+++ b/tests/test_optional_fields_complex_model.py
@@ -8,11 +8,11 @@ from tests.conftest import ComplexModel
 
 @pytest.fixture
 def db_mock_complex(db_mock: SqliterDB) -> SqliterDB:
-    """Ficture for a mock database with a complex model."""
+    """Fixture for a mock database with a complex model."""
     db_mock.create_table(ComplexModel)
     db_mock.insert(
         ComplexModel(
-            id=1,
+            pk=1,
             name="Alice",
             age=30.5,
             is_active=True,
@@ -22,7 +22,7 @@ def db_mock_complex(db_mock: SqliterDB) -> SqliterDB:
     )
     db_mock.insert(
         ComplexModel(
-            id=2,
+            pk=2,
             name="Bob",
             age=25.0,
             is_active=False,
@@ -41,7 +41,7 @@ class TestComplexModelPartialSelection:
         results = db_mock_complex.select(ComplexModel).fetch_all()
         assert len(results) == 2
         for result in results:
-            assert isinstance(result.id, int)
+            assert isinstance(result.pk, int)
             assert isinstance(result.name, str)
             assert isinstance(result.age, float)
             assert isinstance(result.is_active, bool)
@@ -53,13 +53,13 @@ class TestComplexModelPartialSelection:
 
     def test_select_subset_of_fields(self, db_mock_complex: SqliterDB) -> None:
         """Select a subset of fields and ensure their types are correct."""
-        fields = ["id", "name", "age", "is_active", "score"]
+        fields = ["pk", "name", "age", "is_active", "score"]
         results = db_mock_complex.select(
             ComplexModel, fields=fields
         ).fetch_all()
         assert len(results) == 2
         for result in results:
-            assert isinstance(result.id, int)
+            assert isinstance(result.pk, int)
             assert isinstance(result.name, str)
             assert isinstance(result.age, float)
             assert isinstance(result.is_active, bool)
@@ -71,13 +71,13 @@ class TestComplexModelPartialSelection:
         self, db_mock_complex: SqliterDB
     ) -> None:
         """Select a subset of fields and ensure their types are correct."""
-        fields = ["id", "age", "is_active", "score"]
+        fields = ["pk", "age", "is_active", "score"]
         results = db_mock_complex.select(
             ComplexModel, fields=fields
         ).fetch_all()
         assert len(results) == 2
         for result in results:
-            assert isinstance(result.id, int)
+            assert isinstance(result.pk, int)
             assert isinstance(result.age, float)
             assert isinstance(result.is_active, bool)
             assert isinstance(result.score, (int, float))
@@ -107,7 +107,7 @@ class TestComplexModelPartialSelection:
 
     def test_select_with_filtering(self, db_mock_complex: SqliterDB) -> None:
         """Select fields with a filter."""
-        fields = ["id", "name", "age"]
+        fields = ["pk", "name", "age"]
         results = (
             db_mock_complex.select(ComplexModel, fields=fields)
             .filter(age__gt=28)
@@ -119,7 +119,7 @@ class TestComplexModelPartialSelection:
 
     def test_select_with_ordering(self, db_mock_complex: SqliterDB) -> None:
         """Select fields with ordering."""
-        fields = ["id", "name", "age"]
+        fields = ["pk", "name", "age"]
         results = (
             db_mock_complex.select(ComplexModel, fields=fields)
             .order("age", direction="DESC")

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -565,8 +565,8 @@ class TestQuery:
 
         # Create some mock tuples (mimicking database rows)
         mock_result = [
-            ("john", "John", "content"),
-            ("jane", "Jane", "content"),
+            ("1", "john", "John", "content"),
+            ("2", "jane", "Jane", "content"),
         ]
 
         # Mock the _execute_query method on the QueryBuilder instance
@@ -581,5 +581,5 @@ class TestQuery:
         assert not isinstance(result, list)
         assert isinstance(result, ExampleModel)
         assert result == ExampleModel(
-            slug="john", name="John", content="content"
+            pk=1, slug="john", name="John", content="content"
         )

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -583,3 +583,11 @@ class TestQuery:
         assert result == ExampleModel(
             pk=1, slug="john", name="John", content="content"
         )
+
+    def test_exclude_pk_raises_valueerror(self) -> None:
+        """Test that excluding the primary key raises a ValueError."""
+        match_str = "The primary key 'pk' cannot be excluded."
+
+        db = SqliterDB(memory=True)
+        with pytest.raises(ValueError, match=match_str):
+            db.select(ExampleModel).exclude(["pk"])


### PR DESCRIPTION
This is a breaking change, and the `create_pk` and `pk_name` have been removed.

Now, a (hardcoded) `pk` AUTOINCREMENT INT will be created for every model. `insert()` will return this pk if insertion succeeds.