### PR TITLE
Add delete() method to QueryBuilder with comprehensive test coverage

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v4
@@ -29,8 +29,7 @@ jobs:
 
       - name: Run tests
         # For example, using `pytest`
-        run:
-          uv run --all-extras -p ${{ matrix.python-version }} pytest tests
+        run: uv run --all-extras -p ${{ matrix.python-version }} pytest tests
           --cov-report=xml
 
       - name: Run codacy-coverage-reporter

--- a/README.md
+++ b/README.md
@@ -131,8 +131,11 @@ for user in results:
 new_user.age = 31
 db.update(new_user)
 
-# Delete a record
+# Delete a record by primary key
 db.delete(User, new_user.pk)
+
+# Delete all records returned from a query:
+delete_count = db.select(User).filter(age__gt=30).delete()
 ```
 
 See the [Usage](https://sqliter.grantramsay.dev/usage) section of the documentation

--- a/TODO.md
+++ b/TODO.md
@@ -7,10 +7,6 @@ Items marked with :fire: are high priority.
 - add an 'execute' method to the main class to allow executing arbitrary SQL
   queries which can be chained to the 'find_first' etc methods or just used
   directly.
-- add a `delete` method to the QueryBuilder class to allow deleting
-  single/multiple records from the database based on the query. This is in
-  addition to the `delete` method in the main class which deletes a single
-  record based on the primary key.
 - add a `rollback` method to the main class to allow manual rollbacks.
 - :fire: allow adding foreign keys and relationships to each table.
 - add a migration system to allow updating the database schema without losing

--- a/docs/guide/data-operations.md
+++ b/docs/guide/data-operations.md
@@ -111,12 +111,47 @@ timestamp in UTC by default.
 
 ## Deleting Records
 
-To delete a record from the database, you need to pass the model class and the
-primary key value of the record you want to delete:
+SQLiter provides two ways to delete records:
+
+### Single Record Deletion
+
+To delete a single record from the database by its primary key, use the `delete()` method directly on the database instance:
 
 ```python
 db.delete(User, user.pk)
 ```
+
+> [!IMPORTANT]
+>
+> The single record deletion method will raise:
+>
+> - `RecordNotFoundError` if the record with the specified primary key is not found
+> - `RecordDeletionError` if there's an error during the deletion process
+
+### Query-Based Deletion
+
+You can also use a query to delete records that match specific criteria. The `delete()` method will delete all records returned by the query and return an integer with the count of records deleted:
+
+```python
+# Delete all users over 30
+deleted_count = db.select(User).filter(age__gt=30).delete()
+
+# Delete inactive users in a specific age range
+deleted_count = db.select(User).filter(
+    age__gte=25,
+    age__lt=40,
+    status="inactive"
+).delete()
+
+# Delete all records from a table
+deleted_count = db.select(User).delete()
+```
+
+> [!NOTE]
+>
+> The query-based delete operation ignores any `limit()`, `offset()`, or `order()`
+> clauses that might be in the query chain. It will always delete ALL records
+> that match the filter conditions.
 
 ## Commit your changes
 

--- a/docs/guide/guide.md
+++ b/docs/guide/guide.md
@@ -1,4 +1,3 @@
-
 # SQLiter Overview
 
 SQLiter is a lightweight Python library designed to simplify database operations
@@ -122,12 +121,21 @@ db.update(user)
 
 ## Deleting Records
 
-Deleting records is simple as well. You just need to pass the Model that defines
-your table and the primary key value of the record you want to delete:
+SQLiter provides two ways to delete records:
+
+### Single Record Deletion
+
+To delete a single record by its primary key:
 
 ```python
 db.delete(User, 1)
 ```
+
+> [!IMPORTANT]
+>
+> The single record deletion method will raise:
+> - `RecordNotFoundError` if the record with the specified primary key is not found
+> - `RecordDeletionError` if there's an error during the deletion process
 
 > [!NOTE]
 >
@@ -138,6 +146,28 @@ db.delete(User, 1)
 > ```python
 > db.delete(User, new_record.pk)
 > ```
+
+### Query-Based Deletion
+
+You can also delete multiple records that match specific criteria using a query. The `delete()` method will delete all records that match the query and return the number of records deleted:
+
+```python
+# Delete all users over 30
+deleted_count = db.select(User).filter(age__gt=30).delete()
+
+# Delete inactive users in a specific age range
+deleted_count = db.select(User).filter(
+    age__gte=25,
+    age__lt=40,
+    status="inactive"
+).delete()
+```
+
+> [!NOTE]
+>
+> The query-based delete operation ignores any `limit()`, `offset()`, or `order()`
+> clauses that might be in the query chain. It will always delete ALL records
+> that match the filter conditions.
 
 ## Advanced Query Features
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -37,8 +37,11 @@ results = db.select(User).filter(name="John Doe").fetch_one()
 
 print("Updated age:", results.age)
 
-# Delete a record
+# Delete a record by primary key
 db.delete(User, new_user.pk)
+
+# Delete all records returned from a query:
+delete_count = db.select(User).filter(age__gt=30).delete()
 ```
 
 See the [Guide](guide/guide.md) for more detailed information on how to use `SQLiter`.

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -602,7 +602,7 @@ class TestQuery:
             db.select(ExampleModel).exclude(["pk"])
 
     def test_delete_all_records(self, db_mock) -> None:
-        """Test that delete() removes all records when no filters are applied."""
+        """Test delete() removes all records when no filters are applied."""
 
         # Define a simple model for the test
         class DeleteTestModel(BaseDBModel):
@@ -773,7 +773,7 @@ class TestQuery:
         # Drop the table to simulate a database error
         db_mock.drop_table(ErrorDeleteModel)
 
-        # Attempt to delete from the non-existent table should raise RecordDeletionError
+        # Delete from the non-existent table should raise RecordDeletionError
         with pytest.raises(RecordDeletionError) as exc:
             db_mock.select(ErrorDeleteModel).delete()
 


### PR DESCRIPTION
Add a `.delete()` method to the **QueryBuilder** class which will delete all records returned by the query