### PR TITLE
implement list, dict, tuple and set as valid field types

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
       - id: end-of-file-fixer
 
   - repo: https://github.com/renovatebot/pre-commit-hooks
-    rev: 39.133.3
+    rev: 39.137.2
     hooks:
       - id: renovate-config-validator
         files: ^renovate\.json$

--- a/README.md
+++ b/README.md
@@ -19,8 +19,7 @@ time).
 The ideal use case is more for Python CLI tools that need to store data in a
 database-like format without needing to learn SQL or use a full ORM.
 
-Full documentation is available on the [Documentation
-Website](https://sqliter.grantramsay.dev)
+Full documentation is available on the [Website](https://sqliter.grantramsay.dev)
 
 > [!CAUTION]
 > This project is still in the early stages of development and is lacking some
@@ -28,11 +27,6 @@ Website](https://sqliter.grantramsay.dev)
 > change until a stable release is made. I'll try to keep this to an absolute
 > minimum and the releases and documentation will be very clear about any
 > breaking changes.
->
-> Also, structures like `list`, `dict`, `set` etc are not supported **at this
-> time** as field types, since SQLite does not have a native column type for
-> these. This is the **next planned enhancement**. These will need to be
-> `pickled` first then stored as a BLOB in the database.
 >
 > See the [TODO](TODO.md) for planned features and improvements.
 
@@ -46,7 +40,8 @@ Website](https://sqliter.grantramsay.dev)
 ## Features
 
 - Table creation based on Pydantic models
-- Supports `date` and `datetime` fields. List/Dict/Set fields are planned.
+- Supports `date` and `datetime` fields
+- Support for complex data types (`list`, `dict`, `set`, `tuple`) stored as BLOBs
 - Automatic primary key generation
 - User defined indexes on any field
 - Set any field as UNIQUE

--- a/TODO.md
+++ b/TODO.md
@@ -13,13 +13,10 @@ Items marked with :fire: are high priority.
   data.
 - add more tests where 'auto_commit' is set to False to ensure that commit is
   not called automatically.
-- :fire: support structures like, `list`, `dict`, `set`, `tuple` etc. in the
-  model. These will need to be `pickled` first then stored as a BLOB in the
-  database
-- :fire: similarly - perhaps add a `JSON` field type to allow storing JSON data
-  in a field, and an `Object` field type to allow storing arbitrary Python
-  objects? Perhaps a `Binary` field type to allow storing arbitrary binary data?
-  (just uses the existing `bytes` mapping but more explicit)
+- :fire: perhaps add a `JSON` field type to allow storing JSON data in a field,
+  and an `Object` field type to allow storing arbitrary Python objects? Perhaps
+  a `Binary` field type to allow storing arbitrary binary data? (just uses the
+  existing `bytes` mapping but more explicit)
 - Consider performance optimizations for field validation:
   - Benchmark shows ~50% overhead for field assignments with validation
   - Potential solutions:

--- a/TODO.md
+++ b/TODO.md
@@ -20,6 +20,12 @@ Items marked with :fire: are high priority.
   in a field, and an `Object` field type to allow storing arbitrary Python
   objects? Perhaps a `Binary` field type to allow storing arbitrary binary data?
   (just uses the existing `bytes` mapping but more explicit)
+- Consider performance optimizations for field validation:
+  - Benchmark shows ~50% overhead for field assignments with validation
+  - Potential solutions:
+    - Add a "fast mode" configuration option
+    - Create bulk update methods that temporarily disable validation
+    - Optimize validation for specific field types
 - on update, check if the model has actually changed before sending the update
   to the database. This will prevent unnecessary updates and leave the
   `updated_at` correct. However, this will always require a query to the

--- a/demo.py
+++ b/demo.py
@@ -10,7 +10,7 @@ both a functional test and a usage guide for the SQLiter library.
 from __future__ import annotations
 
 import logging
-from typing import ClassVar, Optional
+from typing import Optional
 
 from sqliter import SqliterDB
 from sqliter.exceptions import RecordInsertionError
@@ -26,7 +26,7 @@ class UserModel(BaseDBModel):
     content: Optional[str]
     admin: bool = False
     list_of_str: list[str]
-    a_set: ClassVar[set[str]] = set()
+    a_set: set[str]
 
     class Meta:
         """Override the table name for the UserModel."""
@@ -59,6 +59,7 @@ def main() -> None:
             name="Jane Doe",
             content="This is information about Jane Doe.",
             list_of_str=["x", "y", "z"],
+            a_set={"linux", "mac", "windows"},
         )
         user3 = UserModel(
             slug="jb",

--- a/demo.py
+++ b/demo.py
@@ -10,7 +10,7 @@ both a functional test and a usage guide for the SQLiter library.
 from __future__ import annotations
 
 import logging
-from typing import Optional
+from typing import ClassVar, Optional
 
 from sqliter import SqliterDB
 from sqliter.exceptions import RecordInsertionError
@@ -26,6 +26,7 @@ class UserModel(BaseDBModel):
     content: Optional[str]
     admin: bool = False
     list_of_str: list[str]
+    a_set: ClassVar[set[str]] = set()
 
     class Meta:
         """Override the table name for the UserModel."""
@@ -51,6 +52,7 @@ def main() -> None:
             content="This is information about John Doe.",
             admin=True,
             list_of_str=["a", "b", "c"],
+            a_set={"x", "y", "z"},
         )
         user2 = UserModel(
             slug="jdoe2",
@@ -63,6 +65,7 @@ def main() -> None:
             name="Yogie Bear",
             content=None,
             list_of_str=[],
+            a_set={"apple", "banana", "cherry"},
         )
         try:
             db.insert(user1)

--- a/demo.py
+++ b/demo.py
@@ -25,6 +25,7 @@ class UserModel(BaseDBModel):
     name: str
     content: Optional[str]
     admin: bool = False
+    list_of_str: list[str]
 
     class Meta:
         """Override the table name for the UserModel."""
@@ -49,16 +50,19 @@ def main() -> None:
             name="John Doe",
             content="This is information about John Doe.",
             admin=True,
+            list_of_str=["a", "b", "c"],
         )
         user2 = UserModel(
             slug="jdoe2",
             name="Jane Doe",
             content="This is information about Jane Doe.",
+            list_of_str=["x", "y", "z"],
         )
         user3 = UserModel(
             slug="jb",
             name="Yogie Bear",
             content=None,
+            list_of_str=[],
         )
         try:
             db.insert(user1)

--- a/docs/guide/fields.md
+++ b/docs/guide/fields.md
@@ -53,3 +53,45 @@ This is exactly the same as using the `fields()` method with a single field, but
 very specific and obvious. **There is NO equivalent argument to this in the
 `select()` method**. An exception **WILL** be raised if you try to use this method
 with more than one field.
+
+## Complex Data Types
+
+SQLiter supports storing complex Python data types in the database. The following types are supported:
+
+- `list[T]`: Lists of any type T
+- `dict[K, V]`: Dictionaries with keys of type K and values of type V
+- `set[T]`: Sets of any type T
+- `tuple[T, ...]`: Tuples of any type T
+
+These types are automatically serialized and stored as BLOBs in the database. Here's an example of using complex types:
+
+```python
+from typing import Any
+from sqliter import Model
+
+class UserPreferences(Model):
+    tags: list[str] = []  # List of string tags
+    metadata: dict[str, Any] = {}  # Dictionary with string keys and any value type
+    friends: set[int] = set()  # Set of user IDs
+    coordinates: tuple[float, float] = (0.0, 0.0)  # Tuple of two floats
+
+# Create and save an instance
+prefs = UserPreferences(
+    tags=["python", "sqlite", "orm"],
+    metadata={"theme": "dark", "notifications": True},
+    friends={1, 2, 3},
+    coordinates=(51.5074, -0.1278)
+)
+prefs.save()
+
+# Query and use the complex types
+loaded_prefs = UserPreferences.get(prefs.id)
+print(loaded_prefs.tags)  # ['python', 'sqlite', 'orm']
+print(loaded_prefs.metadata["theme"])  # 'dark'
+print(1 in loaded_prefs.friends)  # True
+print(loaded_prefs.coordinates)  # (51.5074, -0.1278)
+```
+
+The complex types are automatically validated using Pydantic's type system, ensuring that only values of the correct type can be stored. When querying, the values are automatically deserialized back into their original Python types.
+
+Note that since these types are stored as BLOBs, you cannot perform SQL operations on their contents (like searching or filtering). If you need to search or filter based on these values, you should consider storing them in a different format or in separate tables.

--- a/docs/guide/models.md
+++ b/docs/guide/models.md
@@ -37,6 +37,8 @@ the table.
 
 The following field types are currently supported:
 
+Basic Types:
+
 - `str`
 - `int`
 - `float`
@@ -45,9 +47,14 @@ The following field types are currently supported:
 - `datetime`
 - `bytes`
 
-More field types are planned for the near future, since I have the
-serialization/ deserialization locked in. This will include `list`, `dict`,
-`set`, and possibly `JSON` and `Object` fields.
+Complex Types:
+
+- `list[T]` - Lists of any type T
+- `dict[K, V]` - Dictionaries with keys of type K and values of type V
+- `set[T]` - Sets of any type T
+- `tuple[T, ...]` - Tuples of any type T
+
+Complex types are automatically serialized and stored as BLOBs in the database. For more details on using complex types, see the [Fields Guide](fields.md#complex-data-types).
 
 ### Adding Indexes
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,11 +27,6 @@ database-like format without needing to learn SQL or use a full ORM.
 > minimum and the releases and documentation will be very clear about any
 > breaking changes.
 >
-> Also, structures like `list`, `dict`, `set` etc are not supported **at this
-> time** as field types, since SQLite does not have a native column type for
-> these. This is the **next planned enhancement**. These will need to be
-> `pickled` first then stored as a BLOB in the database.
->
 > See the [TODO](todo/index.md) for planned features and improvements.
 
 ## Features

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,6 +105,7 @@ lint.ignore = [
   "FBT002",
   "FBT003",
   "B006",
+  "S301",   # in this library we use 'pickle' for saving and loading list etc
 ] # These rules are too strict even for us 😝
 lint.extend-ignore = [
   "COM812",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -71,7 +71,7 @@ regex==2024.11.6
 requests==2.32.3
 rich==13.9.4
 rtoml==0.12.0
-ruff==0.8.4
+ruff==0.9.3
 shellingham==1.5.4
 simple-toml-settings==0.8.0
 six==1.17.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -36,7 +36,7 @@ mkdocs-material==9.5.49
 mkdocs-material-extensions==1.3.1
 mkdocs-minify-plugin==0.8.0
 mock==5.1.0
-mypy==1.14.0
+mypy==1.14.1
 mypy-extensions==1.0.0
 nodeenv==1.9.1
 packaging==24.2

--- a/sqliter/constants.py
+++ b/sqliter/constants.py
@@ -38,4 +38,8 @@ SQLITE_TYPE_MAPPING = {
     bytes: "BLOB",
     datetime.datetime: "INTEGER",  # Store as Unix timestamp
     datetime.date: "INTEGER",  # Store as Unix timestamp
+    list: "BLOB",
+    dict: "BLOB",
+    set: "BLOB",
+    tuple: "BLOB",
 }

--- a/sqliter/model/model.py
+++ b/sqliter/model/model.py
@@ -10,6 +10,7 @@ in SQLiter applications.
 from __future__ import annotations
 
 import datetime
+import pickle
 import re
 from typing import (
     Any,
@@ -181,7 +182,9 @@ class BaseDBModel(BaseModel):
         """
         if isinstance(value, (datetime.datetime, datetime.date)):
             return to_unix_timestamp(value)
-        return value  # Return value as-is for non-datetime fields
+        if isinstance(value, (list, dict, set, tuple)):
+            return pickle.dumps(value)
+        return value  # Return value as-is for other fields
 
     # Deserialization after fetching from the database
 
@@ -213,4 +216,7 @@ class BaseDBModel(BaseModel):
             return from_unix_timestamp(
                 value, field_type, localize=return_local_time
             )
-        return value  # Return value as-is for non-datetime fields
+
+        if field_type in (list, dict, set, tuple) and isinstance(value, bytes):
+            return pickle.loads(value)  # noqa: S301
+        return value  # Return value as-is for other fields

--- a/sqliter/model/model.py
+++ b/sqliter/model/model.py
@@ -59,7 +59,7 @@ class BaseDBModel(BaseModel):
     model_config = ConfigDict(
         extra="ignore",
         populate_by_name=True,
-        validate_assignment=False,
+        validate_assignment=True,
         from_attributes=True,
     )
 
@@ -231,7 +231,7 @@ class BaseDBModel(BaseModel):
         origin_type = get_origin(field_type) or field_type
         if origin_type in (list, dict, set, tuple) and isinstance(value, bytes):
             try:
-                return pickle.loads(value)  # noqa: S301
+                return pickle.loads(value)
             except pickle.UnpicklingError:
                 return value
 

--- a/sqliter/sqliter.py
+++ b/sqliter/sqliter.py
@@ -549,8 +549,12 @@ class SqliterDB:
                 # Deserialize each field before creating the model instance
                 deserialized_data = {}
                 for field_name, value in result_dict.items():
-                    deserialized_data[field_name] = model_class.deserialize_field(
-                        field_name, value, return_local_time=self.return_local_time
+                    deserialized_data[field_name] = (
+                        model_class.deserialize_field(
+                            field_name,
+                            value,
+                            return_local_time=self.return_local_time,
+                        )
                     )
                 return model_class(**deserialized_data)
         except sqlite3.Error as exc:

--- a/tests/benchmark_validation.py
+++ b/tests/benchmark_validation.py
@@ -1,0 +1,109 @@
+"""Benchmark tests for validation performance."""
+
+# ruff: noqa: T201
+import timeit
+from datetime import datetime, timezone
+from typing import Any
+
+from pydantic import ConfigDict
+
+from sqliter.model import BaseDBModel
+
+
+class ValidatedModel(BaseDBModel):
+    """Model with validation enabled."""
+
+    str_field: str
+    int_field: int
+    list_field: list[str]
+    dict_field: dict[str, Any]
+    date_field: datetime
+
+
+class UnvalidatedModel(BaseDBModel):
+    """Model with validation disabled."""
+
+    str_field: str
+    int_field: int
+    list_field: list[str]
+    dict_field: dict[str, Any]
+    date_field: datetime
+
+    model_config = ConfigDict(
+        validate_assignment=False,
+    )
+
+
+def run_benchmarks(num_iterations: int = 10000) -> None:
+    """Run performance benchmarks.
+
+    Args:
+        num_iterations: Number of iterations for each test.
+    """
+    # Test data
+    test_data = {
+        "str_field": "test",
+        "int_field": 42,
+        "list_field": ["a", "b", "c"],
+        "dict_field": {"key": "value"},
+        "date_field": datetime.now(timezone.utc),
+        "pk": 1,
+    }
+
+    # Initialize models
+    validated = ValidatedModel(**test_data)
+    unvalidated = UnvalidatedModel(**test_data)
+
+    # Benchmark 1: Model Creation
+    create_validated = timeit.timeit(
+        lambda: ValidatedModel(**test_data),
+        number=num_iterations,
+    )
+    create_unvalidated = timeit.timeit(
+        lambda: UnvalidatedModel(**test_data),
+        number=num_iterations,
+    )
+
+    # Benchmark 2: Single Field Assignment
+    assign_validated = timeit.timeit(
+        lambda: setattr(validated, "str_field", "new value"),
+        number=num_iterations,
+    )
+    assign_unvalidated = timeit.timeit(
+        lambda: setattr(unvalidated, "str_field", "new value"),
+        number=num_iterations,
+    )
+
+    # Benchmark 3: Complex Field Assignment
+    complex_data = ["item1", "item2", "item3"]
+    assign_complex_validated = timeit.timeit(
+        lambda: setattr(validated, "list_field", complex_data),
+        number=num_iterations,
+    )
+    assign_complex_unvalidated = timeit.timeit(
+        lambda: setattr(unvalidated, "list_field", complex_data),
+        number=num_iterations,
+    )
+
+    # Print results
+    print(f"\nBenchmark Results ({num_iterations:,} iterations each):")
+    print("-" * 60)
+    print("1. Model Creation:")
+    print(f"   With validation:    {create_validated:.4f} seconds")
+    print(f"   Without validation: {create_unvalidated:.4f} seconds")
+    overhead = (create_validated / create_unvalidated) - 1
+    print(f"   Overhead: {overhead * 100:.1f}%")
+    print("\n2. Simple Field Assignment (str):")
+    print(f"   With validation:    {assign_validated:.4f} seconds")
+    print(f"   Without validation: {assign_unvalidated:.4f} seconds")
+    overhead = (assign_validated / assign_unvalidated) - 1
+    print(f"   Overhead: {overhead * 100:.1f}%")
+    print("\n3. Complex Field Assignment (list):")
+    print(f"   With validation:    {assign_complex_validated:.4f} seconds")
+    print(f"   Without validation: {assign_complex_unvalidated:.4f} seconds")
+    overhead = (assign_complex_validated / assign_complex_unvalidated) - 1
+    print(f"   Overhead: {overhead * 100:.1f}%")
+
+
+if __name__ == "__main__":
+    run_benchmarks()

--- a/tests/test_complex_types.py
+++ b/tests/test_complex_types.py
@@ -1,0 +1,237 @@
+"""Test serialization and deserialization of complex data types."""
+
+import pickle
+from typing import Any, ClassVar, Union
+
+import pytest
+from pydantic_core import ValidationError
+
+from sqliter import SqliterDB
+from sqliter.model import BaseDBModel
+
+
+class ComplexTypesModel(BaseDBModel):
+    """Model for testing complex data types."""
+
+    list_field: list[str]
+    dict_field: dict[str, Any]
+    set_field: set[int]
+    tuple_field: tuple[str, int, bool]
+    empty_list: ClassVar[list[str]] = []
+    empty_dict: ClassVar[dict[str, Any]] = {}
+    empty_set: ClassVar[set[int]] = set()
+    empty_tuple: ClassVar[tuple[()]] = ()
+
+
+class TestComplexTypes:
+    """Test class for complex type serialization/deserialization."""
+
+    @pytest.fixture
+    def model_instance(self) -> ComplexTypesModel:
+        """Create a test model instance with complex types."""
+        return ComplexTypesModel(
+            list_field=["a", "b", "c"],
+            dict_field={"key1": "value1", "key2": 123, "key3": True},
+            set_field={1, 2, 3},
+            tuple_field=("test", 42, True),
+            empty_list=[],
+            empty_dict={},
+            empty_set=set(),
+            empty_tuple=(),
+        )
+
+    def test_serialize_list(self, model_instance: ComplexTypesModel) -> None:
+        """Test serialization of list field."""
+        result = model_instance.serialize_field(model_instance.list_field)
+        assert isinstance(result, bytes)  # Should be pickled
+        assert model_instance.deserialize_field(
+            "list_field", result, return_local_time=True
+        ) == ["a", "b", "c"]
+
+    def test_serialize_dict(self, model_instance: ComplexTypesModel) -> None:
+        """Test serialization of dictionary field."""
+        result = model_instance.serialize_field(model_instance.dict_field)
+        assert isinstance(result, bytes)  # Should be pickled
+        assert model_instance.deserialize_field(
+            "dict_field", result, return_local_time=True
+        ) == {"key1": "value1", "key2": 123, "key3": True}
+
+    def test_serialize_set(self, model_instance: ComplexTypesModel) -> None:
+        """Test serialization of set field."""
+        result = model_instance.serialize_field(model_instance.set_field)
+        assert isinstance(result, bytes)  # Should be pickled
+        assert model_instance.deserialize_field(
+            "set_field", result, return_local_time=True
+        ) == {1, 2, 3}
+
+    def test_serialize_tuple(self, model_instance: ComplexTypesModel) -> None:
+        """Test serialization of tuple field."""
+        result = model_instance.serialize_field(model_instance.tuple_field)
+        assert isinstance(result, bytes)  # Should be pickled
+        assert model_instance.deserialize_field(
+            "tuple_field", result, return_local_time=True
+        ) == ("test", 42, True)
+
+    def test_list_type_preservation(
+        self, model_instance: ComplexTypesModel
+    ) -> None:
+        """Test list maintains its type after serialization/deserialization."""
+        result = model_instance.serialize_field(model_instance.list_field)
+        deserialized = model_instance.deserialize_field(
+            "list_field", result, return_local_time=True
+        )
+        assert isinstance(deserialized, list)
+        assert deserialized == model_instance.list_field
+
+    def test_dict_type_preservation(
+        self, model_instance: ComplexTypesModel
+    ) -> None:
+        """Test dict maintains its type after serialization/deserialization."""
+        result = model_instance.serialize_field(model_instance.dict_field)
+        deserialized = model_instance.deserialize_field(
+            "dict_field", result, return_local_time=True
+        )
+        assert isinstance(deserialized, dict)
+        assert deserialized == model_instance.dict_field
+
+    def test_set_type_preservation(
+        self, model_instance: ComplexTypesModel
+    ) -> None:
+        """Test set maintains its type after serialization/deserialization."""
+        result = model_instance.serialize_field(model_instance.set_field)
+        deserialized = model_instance.deserialize_field(
+            "set_field", result, return_local_time=True
+        )
+        assert isinstance(deserialized, set)
+        assert deserialized == model_instance.set_field
+
+    def test_tuple_type_preservation(
+        self, model_instance: ComplexTypesModel
+    ) -> None:
+        """Test tuple maintains its type after serialization/deserialization."""
+        result = model_instance.serialize_field(model_instance.tuple_field)
+        deserialized = model_instance.deserialize_field(
+            "tuple_field", result, return_local_time=True
+        )
+        assert isinstance(deserialized, tuple)
+        assert deserialized == model_instance.tuple_field
+
+    def test_empty_containers(self, model_instance: ComplexTypesModel) -> None:
+        """Test serialization of empty containers."""
+        # Test empty list
+        result = model_instance.serialize_field(model_instance.empty_list)
+        assert isinstance(result, bytes)
+        assert pickle.loads(result) == []
+
+        # Test empty dict
+        result = model_instance.serialize_field(model_instance.empty_dict)
+        assert isinstance(result, bytes)
+        assert pickle.loads(result) == {}
+
+        # Test empty set
+        result = model_instance.serialize_field(model_instance.empty_set)
+        assert isinstance(result, bytes)
+        assert pickle.loads(result) == set()
+
+        # Test empty tuple
+        result = model_instance.serialize_field(model_instance.empty_tuple)
+        assert isinstance(result, bytes)
+        assert pickle.loads(result) == ()
+
+    def test_nested_structures(self) -> None:
+        """Test serialization of nested data structures."""
+
+        class NestedModel(BaseDBModel):
+            nested_field: list[dict[str, list[int]]]
+
+        nested_data = [{"nums": [1, 2, 3]}, {"nums": [4, 5, 6]}]
+        model = NestedModel(nested_field=nested_data)
+
+        result = model.serialize_field(model.nested_field)
+        assert isinstance(result, bytes)
+        assert (
+            model.deserialize_field(
+                "nested_field", result, return_local_time=True
+            )
+            == nested_data
+        )
+
+    def test_invalid_pickle_data(
+        self, model_instance: ComplexTypesModel
+    ) -> None:
+        """Test handling of invalid pickle data."""
+        invalid_bytes = b"invalid pickle data"
+        # Should return the original value when unpickling fails
+        assert (
+            model_instance.deserialize_field(
+                "list_field", invalid_bytes, return_local_time=True
+            )
+            == invalid_bytes
+        )
+
+    def test_none_values(self, model_instance: ComplexTypesModel) -> None:
+        """Test handling of None values."""
+        assert (
+            model_instance.deserialize_field(
+                "list_field", None, return_local_time=True
+            )
+            is None
+        )
+
+    @pytest.mark.parametrize(
+        ("field_name", "invalid_value"),
+        [
+            ("list_field", "not a list"),
+            ("dict_field", [1, 2, 3]),  # List instead of dict
+            ("set_field", {"key": "value"}),  # Dict instead of set
+            ("tuple_field", {1, 2, 3}),  # Set instead of tuple
+        ],
+        ids=["list", "dict", "set", "tuple"],
+    )
+    def test_type_validation(
+        self,
+        model_instance: ComplexTypesModel,
+        field_name: str,
+        invalid_value: Union[
+            list[Any], dict[Any, Any], set[Any], tuple[Any, ...]
+        ],
+    ) -> None:
+        """Test validation of incorrect types."""
+        with pytest.raises(ValidationError):
+            setattr(model_instance, field_name, invalid_value)
+
+    def test_db_roundtrip_type_preservation(
+        self, model_instance: ComplexTypesModel, tmp_path: str
+    ) -> None:
+        """Test complex types maintain their types after database save/load."""
+        db_path = f"{tmp_path}/test.db"
+        db = SqliterDB(db_path)
+        db.create_table(ComplexTypesModel)
+
+        # Save to database
+        saved = db.insert(model_instance)
+
+        # Read back from database
+        loaded = db.get(ComplexTypesModel, saved.pk)
+
+        # Ensure we got a result back
+        assert loaded is not None, "Failed to load model from database"
+
+        # Check each field maintains both type and value
+        assert isinstance(loaded.list_field, list)
+        assert loaded.list_field == ["a", "b", "c"]
+
+        assert isinstance(loaded.dict_field, dict)
+        assert loaded.dict_field == {
+            "key1": "value1",
+            "key2": 123,
+            "key3": True,
+        }
+
+        assert isinstance(loaded.set_field, set)
+        assert loaded.set_field == {1, 2, 3}
+
+        assert isinstance(loaded.tuple_field, tuple)
+        assert loaded.tuple_field == ("test", 42, True)
+
+        db.close()

--- a/tests/test_complex_types.py
+++ b/tests/test_complex_types.py
@@ -235,3 +235,143 @@ class TestComplexTypes:
         assert loaded.tuple_field == ("test", 42, True)
 
         db.close()
+
+    def test_update_list_field(
+        self, model_instance: ComplexTypesModel, tmp_path: str
+    ) -> None:
+        """Test updating a record's list field."""
+        db_path = f"{tmp_path}/test_update_list.db"
+        db = SqliterDB(db_path)
+        db.create_table(ComplexTypesModel)
+
+        # Save initial record
+        saved = db.insert(model_instance)
+        assert saved.list_field == ["a", "b", "c"]
+
+        # Update the list field
+        saved.list_field = ["x", "y", "z"]
+        db.update(saved)
+
+        # Read back and verify
+        loaded = db.get(ComplexTypesModel, saved.pk)
+        assert loaded is not None
+        assert isinstance(loaded.list_field, list)
+        assert loaded.list_field == ["x", "y", "z"]
+
+        db.close()
+
+    def test_update_dict_field(
+        self, model_instance: ComplexTypesModel, tmp_path: str
+    ) -> None:
+        """Test updating a record's dictionary field."""
+        db_path = f"{tmp_path}/test_update_dict.db"
+        db = SqliterDB(db_path)
+        db.create_table(ComplexTypesModel)
+
+        # Save initial record
+        saved = db.insert(model_instance)
+        assert saved.dict_field == {"key1": "value1", "key2": 123, "key3": True}
+
+        # Update the dict field
+        new_dict = {
+            "new_key1": "new_value1",
+            "new_key2": 456,
+            "new_key3": False,
+        }
+        saved.dict_field = new_dict
+        db.update(saved)
+
+        # Read back and verify
+        loaded = db.get(ComplexTypesModel, saved.pk)
+        assert loaded is not None
+        assert isinstance(loaded.dict_field, dict)
+        assert loaded.dict_field == new_dict
+
+        db.close()
+
+    def test_update_set_field(
+        self, model_instance: ComplexTypesModel, tmp_path: str
+    ) -> None:
+        """Test updating a record's set field."""
+        db_path = f"{tmp_path}/test_update_set.db"
+        db = SqliterDB(db_path)
+        db.create_table(ComplexTypesModel)
+
+        # Save initial record
+        saved = db.insert(model_instance)
+        assert saved.set_field == {1, 2, 3}
+
+        # Update the set field
+        new_set = {4, 5, 6}
+        saved.set_field = new_set
+        db.update(saved)
+
+        # Read back and verify
+        loaded = db.get(ComplexTypesModel, saved.pk)
+        assert loaded is not None
+        assert isinstance(loaded.set_field, set)
+        assert loaded.set_field == new_set
+
+        db.close()
+
+    def test_update_tuple_field(
+        self, model_instance: ComplexTypesModel, tmp_path: str
+    ) -> None:
+        """Test updating a record's tuple field."""
+        db_path = f"{tmp_path}/test_update_tuple.db"
+        db = SqliterDB(db_path)
+        db.create_table(ComplexTypesModel)
+
+        # Save initial record
+        saved = db.insert(model_instance)
+        assert saved.tuple_field == ("test", 42, True)
+
+        # Update the tuple field
+        new_tuple = ("updated", 99, False)
+        saved.tuple_field = new_tuple
+        db.update(saved)
+
+        # Read back and verify
+        loaded = db.get(ComplexTypesModel, saved.pk)
+        assert loaded is not None
+        assert isinstance(loaded.tuple_field, tuple)
+        assert loaded.tuple_field == new_tuple
+
+        db.close()
+
+    def test_update_multiple_complex_fields(
+        self, model_instance: ComplexTypesModel, tmp_path: str
+    ) -> None:
+        """Test updating multiple complex fields simultaneously."""
+        db_path = f"{tmp_path}/test_update_multiple.db"
+        db = SqliterDB(db_path)
+        db.create_table(ComplexTypesModel)
+
+        # Save initial record
+        saved = db.insert(model_instance)
+
+        # Update all complex fields
+        saved.list_field = ["x", "y", "z"]
+        saved.dict_field = {"new": "value"}
+        saved.set_field = {7, 8, 9}
+        saved.tuple_field = ("new", 100, False)
+        db.update(saved)
+
+        # Read back and verify
+        loaded = db.get(ComplexTypesModel, saved.pk)
+        assert loaded is not None
+
+        # Verify all fields were updated correctly
+        assert isinstance(loaded.list_field, list)
+        assert loaded.list_field == ["x", "y", "z"]
+
+        assert isinstance(loaded.dict_field, dict)
+        assert loaded.dict_field == {"new": "value"}
+
+        assert isinstance(loaded.set_field, set)
+        assert loaded.set_field == {7, 8, 9}
+
+        assert isinstance(loaded.tuple_field, tuple)
+        assert loaded.tuple_field == ("new", 100, False)
+
+        db.close()

--- a/tests/test_complex_types.py
+++ b/tests/test_complex_types.py
@@ -1,4 +1,5 @@
 """Test serialization and deserialization of complex data types."""
+# ruff: noqa: C405  # Allow set([...]) syntax in tests to verify we both handle both forms
 
 import pickle
 from typing import Any, ClassVar, Union

--- a/tests/test_debug_logging.py
+++ b/tests/test_debug_logging.py
@@ -17,16 +17,16 @@ class TestDebugLogging:
     def test_sqliterdb_debug_set_false(self) -> None:
         """Test that the default value for the debug flag is False."""
         db = SqliterDB(":memory:", debug=False)  # Set debug argument to False
-        assert (
-            db.debug is False
-        ), "The debug flag should be False when explicitly passed as False."
+        assert db.debug is False, (
+            "The debug flag should be False when explicitly passed as False."
+        )
 
     def test_sqliterdb_debug_set_true(self) -> None:
         """Test that the debug flag can be set to True."""
         db = SqliterDB(":memory:", debug=True)  # Set debug argument to True
-        assert (
-            db.debug is True
-        ), "The debug flag should be True when explicitly passed as True."
+        assert db.debug is True, (
+            "The debug flag should be True when explicitly passed as True."
+        )
 
     def test_debug_sql_output_basic_query(
         self, db_mock_complex_debug: SqliterDB, caplog

--- a/tests/test_debug_logging.py
+++ b/tests/test_debug_logging.py
@@ -17,16 +17,16 @@ class TestDebugLogging:
     def test_sqliterdb_debug_set_false(self) -> None:
         """Test that the default value for the debug flag is False."""
         db = SqliterDB(":memory:", debug=False)  # Set debug argument to False
-        assert db.debug is False, (
-            "The debug flag should be False when explicitly passed as False."
-        )
+        assert (
+            db.debug is False
+        ), "The debug flag should be False when explicitly passed as False."
 
     def test_sqliterdb_debug_set_true(self) -> None:
         """Test that the debug flag can be set to True."""
         db = SqliterDB(":memory:", debug=True)  # Set debug argument to True
-        assert db.debug is True, (
-            "The debug flag should be True when explicitly passed as True."
-        )
+        assert (
+            db.debug is True
+        ), "The debug flag should be True when explicitly passed as True."
 
     def test_debug_sql_output_basic_query(
         self, db_mock_complex_debug: SqliterDB, caplog
@@ -271,3 +271,35 @@ class TestDebugLogging:
             SqliterDB(temp_db_path, reset=True, debug=True)
 
         assert "Database reset: 0 user-created tables dropped." in caplog.text
+
+    def test_setup_logger_else_clause(self, mocker) -> None:
+        """Test the else clause configuration for the logger setup."""
+        # Mock the root logger's hasHandlers BEFORE creating the instance
+        mocker.patch.object(
+            logging.getLogger(), "hasHandlers", return_value=False
+        )
+
+        # Now create the instance which will trigger _setup_logger
+        instance = SqliterDB(":memory:", debug=True)
+
+        # Verify the else clause configuration
+        logger = instance.logger
+        assert logger is not None
+
+        assert logger.name == "sqliter"
+        assert len(logger.handlers) == 1
+
+        handler = logger.handlers[0]
+        assert isinstance(handler, logging.StreamHandler)
+        assert handler.formatter is not None
+        assert handler.formatter._fmt == "%(levelname)-8s%(message)s"
+        assert logger.level == logging.DEBUG
+        assert logger.propagate is False
+
+        logging.getLogger().hasHandlers.assert_called_once()
+
+        # Cleanup - crucial to prevent test pollution
+        for hdlr in logger.handlers[:]:
+            logger.removeHandler(hdlr)
+        logger.setLevel(logging.NOTSET)
+        logger.propagate = True

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -19,9 +19,11 @@ class TestHelpers:
         # Test with None
         assert infer_sqlite_type(None) == "TEXT"
 
+        # test with collection types
+        assert infer_sqlite_type(list) == "BLOB"
+        assert infer_sqlite_type(dict) == "BLOB"
+        assert infer_sqlite_type(tuple) == "BLOB"
+        assert infer_sqlite_type(set) == "BLOB"
+
         # Test with an unsupported type
-        assert infer_sqlite_type(list) == "TEXT"
-        assert infer_sqlite_type(dict) == "TEXT"
-        assert infer_sqlite_type(tuple) == "TEXT"
-        assert infer_sqlite_type(set) == "TEXT"
         assert infer_sqlite_type(Union) == "TEXT"

--- a/uv.lock
+++ b/uv.lock
@@ -185,7 +185,7 @@ name = "click"
 version = "8.1.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "platform_system == 'Windows'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b9/2e/0090cbf739cee7d23781ad4b89a9894a41538e4fcf4c31dcdd705b78eb8b/click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a", size = 226593 }
 wheels = [
@@ -591,7 +591,7 @@ version = "1.6.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
-    { name = "colorama", marker = "platform_system == 'Windows'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
     { name = "ghp-import" },
     { name = "importlib-metadata", marker = "python_full_version < '3.10'" },
     { name = "jinja2" },
@@ -682,41 +682,46 @@ wheels = [
 
 [[package]]
 name = "mypy"
-version = "1.14.0"
+version = "1.14.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "mypy-extensions" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8c/7b/08046ef9330735f536a09a2e31b00f42bccdb2795dcd979636ba43bb2d63/mypy-1.14.0.tar.gz", hash = "sha256:822dbd184d4a9804df5a7d5335a68cf7662930e70b8c1bc976645d1509f9a9d6", size = 3215684 }
+sdist = { url = "https://files.pythonhosted.org/packages/b9/eb/2c92d8ea1e684440f54fa49ac5d9a5f19967b7b472a281f419e69a8d228e/mypy-1.14.1.tar.gz", hash = "sha256:7ec88144fe9b510e8475ec2f5f251992690fcf89ccb4500b214b4226abcd32d6", size = 3216051 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ef/97/f00ded038482230e0beaaa08f9c5483a54530b362ad1b0d752d5d2b2f211/mypy-1.14.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:e971c1c667007f9f2b397ffa80fa8e1e0adccff336e5e77e74cb5f22868bee87", size = 11207956 },
-    { url = "https://files.pythonhosted.org/packages/68/67/8b4db0da19c9e3fa6264e948f1c135ab4dd45bede1809f4fdb613dc119f6/mypy-1.14.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:e86aaeaa3221a278c66d3d673b297232947d873773d61ca3ee0e28b2ff027179", size = 10363681 },
-    { url = "https://files.pythonhosted.org/packages/f5/00/56b1619ff1f3fcad2d411eccda60d74d20e73bda39c218d5ad2769980682/mypy-1.14.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1628c5c3ce823d296e41e2984ff88c5861499041cb416a8809615d0c1f41740e", size = 12832976 },
-    { url = "https://files.pythonhosted.org/packages/e7/8b/9247838774b0bd865f190cc221822212091317f16310305ef924d9772532/mypy-1.14.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:7fadb29b77fc14a0dd81304ed73c828c3e5cde0016c7e668a86a3e0dfc9f3af3", size = 13013704 },
-    { url = "https://files.pythonhosted.org/packages/b2/69/0c0868a6f3d9761d2f704d1fb6ef84d75998c27d342738a8b20f109a411f/mypy-1.14.0-cp310-cp310-win_amd64.whl", hash = "sha256:3fa76988dc760da377c1e5069200a50d9eaaccf34f4ea18428a3337034ab5a44", size = 9782230 },
-    { url = "https://files.pythonhosted.org/packages/34/c1/b9dd3e955953aec1c728992545b7877c9f6fa742a623ce4c200da0f62540/mypy-1.14.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:6e73c8a154eed31db3445fe28f63ad2d97b674b911c00191416cf7f6459fd49a", size = 11121032 },
-    { url = "https://files.pythonhosted.org/packages/ee/96/c52d5d516819ab95bf41f4a1ada828a3decc302f8c152ff4fc5feb0e4529/mypy-1.14.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:273e70fcb2e38c5405a188425aa60b984ffdcef65d6c746ea5813024b68c73dc", size = 10286294 },
-    { url = "https://files.pythonhosted.org/packages/69/2c/3dbe51877a24daa467f8d8631f9ffd1aabbf0f6d9367a01c44a59df81fe0/mypy-1.14.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1daca283d732943731a6a9f20fdbcaa927f160bc51602b1d4ef880a6fb252015", size = 12746528 },
-    { url = "https://files.pythonhosted.org/packages/a1/a8/eb20cde4ba9c4c3e20d958918a7c5d92210f4d1a0200c27de9a641f70996/mypy-1.14.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:7e68047bedb04c1c25bba9901ea46ff60d5eaac2d71b1f2161f33107e2b368eb", size = 12883489 },
-    { url = "https://files.pythonhosted.org/packages/91/17/a1fc6c70f31d52c99299320cf81c3cb2c6b91ec7269414e0718a6d138e34/mypy-1.14.0-cp311-cp311-win_amd64.whl", hash = "sha256:7a52f26b9c9b1664a60d87675f3bae00b5c7f2806e0c2800545a32c325920bcc", size = 9780113 },
-    { url = "https://files.pythonhosted.org/packages/fe/d8/0e72175ee0253217f5c44524f5e95251c02e95ba9749fb87b0e2074d203a/mypy-1.14.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d5326ab70a6db8e856d59ad4cb72741124950cbbf32e7b70e30166ba7bbf61dd", size = 11269011 },
-    { url = "https://files.pythonhosted.org/packages/e9/6d/4ea13839dabe5db588dc6a1b766da16f420d33cf118a7b7172cdf6c7fcb2/mypy-1.14.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:bf4ec4980bec1e0e24e5075f449d014011527ae0055884c7e3abc6a99cd2c7f1", size = 10253076 },
-    { url = "https://files.pythonhosted.org/packages/3e/38/7db2c5d0f4d290e998f7a52b2e2616c7bbad96b8e04278ab09d11978a29e/mypy-1.14.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:390dfb898239c25289495500f12fa73aa7f24a4c6d90ccdc165762462b998d63", size = 12862786 },
-    { url = "https://files.pythonhosted.org/packages/bf/4b/62d59c801b34141040989949c2b5c157d0408b45357335d3ec5b2845b0f6/mypy-1.14.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:7e026d55ddcd76e29e87865c08cbe2d0104e2b3153a523c529de584759379d3d", size = 12971568 },
-    { url = "https://files.pythonhosted.org/packages/f1/9c/e0f281b32d70c87b9e4d2939e302b1ff77ada4d7b0f2fb32890c144bc1d6/mypy-1.14.0-cp312-cp312-win_amd64.whl", hash = "sha256:585ed36031d0b3ee362e5107ef449a8b5dfd4e9c90ccbe36414ee405ee6b32ba", size = 9879477 },
-    { url = "https://files.pythonhosted.org/packages/13/33/8380efd0ebdfdfac7fc0bf065f03a049800ca1e6c296ec1afc634340d992/mypy-1.14.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e9f6f4c0b27401d14c483c622bc5105eff3911634d576bbdf6695b9a7c1ba741", size = 11251509 },
-    { url = "https://files.pythonhosted.org/packages/15/6d/4e1c21c60fee11af7d8e4f2902a29886d1387d6a836be16229eb3982a963/mypy-1.14.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:56b2280cedcb312c7a79f5001ae5325582d0d339bce684e4a529069d0e7ca1e7", size = 10244282 },
-    { url = "https://files.pythonhosted.org/packages/8b/cf/7a8ae5c0161edae15d25c2c67c68ce8b150cbdc45aefc13a8be271ee80b2/mypy-1.14.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:342de51c48bab326bfc77ce056ba08c076d82ce4f5a86621f972ed39970f94d8", size = 12867676 },
-    { url = "https://files.pythonhosted.org/packages/9c/d0/71f7bbdcc7cfd0f2892db5b13b1e8857673f2cc9e0c30e3e4340523dc186/mypy-1.14.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:00df23b42e533e02a6f0055e54de9a6ed491cd8b7ea738647364fd3a39ea7efc", size = 12964189 },
-    { url = "https://files.pythonhosted.org/packages/a7/40/fb4ad65d6d5f8c51396ecf6305ec0269b66013a5bf02d0e9528053640b4a/mypy-1.14.0-cp313-cp313-win_amd64.whl", hash = "sha256:e8c8387e5d9dff80e7daf961df357c80e694e942d9755f3ad77d69b0957b8e3f", size = 9888247 },
-    { url = "https://files.pythonhosted.org/packages/aa/b7/7f04baf45d3f7fd15eb2e24ca225f93713a43fa3b7fb4ec85329e6849a50/mypy-1.14.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:14117b9da3305b39860d0aa34b8f1ff74d209a368829a584eb77524389a9c13e", size = 11202640 },
-    { url = "https://files.pythonhosted.org/packages/1c/03/3d27a64baaa70d8218556a08d93fc64e0d3a46b81bae0e2c93511be85264/mypy-1.14.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:af98c5a958f9c37404bd4eef2f920b94874507e146ed6ee559f185b8809c44cc", size = 10354715 },
-    { url = "https://files.pythonhosted.org/packages/bb/bd/a0eb1789dfeaab0ca93d00f373c002cac4734e8f902de4e7eceb9245a116/mypy-1.14.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f0b343a1d3989547024377c2ba0dca9c74a2428ad6ed24283c213af8dbb0710b", size = 12832863 },
-    { url = "https://files.pythonhosted.org/packages/ef/0c/d404be19b1145f9371c4d4fdfc166337a2810c2be0f19dec5965186e8fab/mypy-1.14.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:cdb5563c1726c85fb201be383168f8c866032db95e1095600806625b3a648cb7", size = 13008982 },
-    { url = "https://files.pythonhosted.org/packages/3e/2c/f02dbde7609de72160459767bfb12490e1e30e33e3d01a6c68d5934f73df/mypy-1.14.0-cp39-cp39-win_amd64.whl", hash = "sha256:74e925649c1ee0a79aa7448baf2668d81cc287dc5782cff6a04ee93f40fb8d3f", size = 9781353 },
-    { url = "https://files.pythonhosted.org/packages/39/32/0214608af400cdf8f5102144bb8af10d880675c65ed0b58f7e0e77175d50/mypy-1.14.0-py3-none-any.whl", hash = "sha256:2238d7f93fc4027ed1efc944507683df3ba406445a2b6c96e79666a045aadfab", size = 2752803 },
+    { url = "https://files.pythonhosted.org/packages/9b/7a/87ae2adb31d68402da6da1e5f30c07ea6063e9f09b5e7cfc9dfa44075e74/mypy-1.14.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:52686e37cf13d559f668aa398dd7ddf1f92c5d613e4f8cb262be2fb4fedb0fcb", size = 11211002 },
+    { url = "https://files.pythonhosted.org/packages/e1/23/eada4c38608b444618a132be0d199b280049ded278b24cbb9d3fc59658e4/mypy-1.14.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:1fb545ca340537d4b45d3eecdb3def05e913299ca72c290326be19b3804b39c0", size = 10358400 },
+    { url = "https://files.pythonhosted.org/packages/43/c9/d6785c6f66241c62fd2992b05057f404237deaad1566545e9f144ced07f5/mypy-1.14.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:90716d8b2d1f4cd503309788e51366f07c56635a3309b0f6a32547eaaa36a64d", size = 12095172 },
+    { url = "https://files.pythonhosted.org/packages/c3/62/daa7e787770c83c52ce2aaf1a111eae5893de9e004743f51bfcad9e487ec/mypy-1.14.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2ae753f5c9fef278bcf12e1a564351764f2a6da579d4a81347e1d5a15819997b", size = 12828732 },
+    { url = "https://files.pythonhosted.org/packages/1b/a2/5fb18318a3637f29f16f4e41340b795da14f4751ef4f51c99ff39ab62e52/mypy-1.14.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:e0fe0f5feaafcb04505bcf439e991c6d8f1bf8b15f12b05feeed96e9e7bf1427", size = 13012197 },
+    { url = "https://files.pythonhosted.org/packages/28/99/e153ce39105d164b5f02c06c35c7ba958aaff50a2babba7d080988b03fe7/mypy-1.14.1-cp310-cp310-win_amd64.whl", hash = "sha256:7d54bd85b925e501c555a3227f3ec0cfc54ee8b6930bd6141ec872d1c572f81f", size = 9780836 },
+    { url = "https://files.pythonhosted.org/packages/da/11/a9422850fd506edbcdc7f6090682ecceaf1f87b9dd847f9df79942da8506/mypy-1.14.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f995e511de847791c3b11ed90084a7a0aafdc074ab88c5a9711622fe4751138c", size = 11120432 },
+    { url = "https://files.pythonhosted.org/packages/b6/9e/47e450fd39078d9c02d620545b2cb37993a8a8bdf7db3652ace2f80521ca/mypy-1.14.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:d64169ec3b8461311f8ce2fd2eb5d33e2d0f2c7b49116259c51d0d96edee48d1", size = 10279515 },
+    { url = "https://files.pythonhosted.org/packages/01/b5/6c8d33bd0f851a7692a8bfe4ee75eb82b6983a3cf39e5e32a5d2a723f0c1/mypy-1.14.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ba24549de7b89b6381b91fbc068d798192b1b5201987070319889e93038967a8", size = 12025791 },
+    { url = "https://files.pythonhosted.org/packages/f0/4c/e10e2c46ea37cab5c471d0ddaaa9a434dc1d28650078ac1b56c2d7b9b2e4/mypy-1.14.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:183cf0a45457d28ff9d758730cd0210419ac27d4d3f285beda038c9083363b1f", size = 12749203 },
+    { url = "https://files.pythonhosted.org/packages/88/55/beacb0c69beab2153a0f57671ec07861d27d735a0faff135a494cd4f5020/mypy-1.14.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:f2a0ecc86378f45347f586e4163d1769dd81c5a223d577fe351f26b179e148b1", size = 12885900 },
+    { url = "https://files.pythonhosted.org/packages/a2/75/8c93ff7f315c4d086a2dfcde02f713004357d70a163eddb6c56a6a5eff40/mypy-1.14.1-cp311-cp311-win_amd64.whl", hash = "sha256:ad3301ebebec9e8ee7135d8e3109ca76c23752bac1e717bc84cd3836b4bf3eae", size = 9777869 },
+    { url = "https://files.pythonhosted.org/packages/43/1b/b38c079609bb4627905b74fc6a49849835acf68547ac33d8ceb707de5f52/mypy-1.14.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:30ff5ef8519bbc2e18b3b54521ec319513a26f1bba19a7582e7b1f58a6e69f14", size = 11266668 },
+    { url = "https://files.pythonhosted.org/packages/6b/75/2ed0d2964c1ffc9971c729f7a544e9cd34b2cdabbe2d11afd148d7838aa2/mypy-1.14.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:cb9f255c18052343c70234907e2e532bc7e55a62565d64536dbc7706a20b78b9", size = 10254060 },
+    { url = "https://files.pythonhosted.org/packages/a1/5f/7b8051552d4da3c51bbe8fcafffd76a6823779101a2b198d80886cd8f08e/mypy-1.14.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8b4e3413e0bddea671012b063e27591b953d653209e7a4fa5e48759cda77ca11", size = 11933167 },
+    { url = "https://files.pythonhosted.org/packages/04/90/f53971d3ac39d8b68bbaab9a4c6c58c8caa4d5fd3d587d16f5927eeeabe1/mypy-1.14.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:553c293b1fbdebb6c3c4030589dab9fafb6dfa768995a453d8a5d3b23784af2e", size = 12864341 },
+    { url = "https://files.pythonhosted.org/packages/03/d2/8bc0aeaaf2e88c977db41583559319f1821c069e943ada2701e86d0430b7/mypy-1.14.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fad79bfe3b65fe6a1efaed97b445c3d37f7be9fdc348bdb2d7cac75579607c89", size = 12972991 },
+    { url = "https://files.pythonhosted.org/packages/6f/17/07815114b903b49b0f2cf7499f1c130e5aa459411596668267535fe9243c/mypy-1.14.1-cp312-cp312-win_amd64.whl", hash = "sha256:8fa2220e54d2946e94ab6dbb3ba0a992795bd68b16dc852db33028df2b00191b", size = 9879016 },
+    { url = "https://files.pythonhosted.org/packages/9e/15/bb6a686901f59222275ab228453de741185f9d54fecbaacec041679496c6/mypy-1.14.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:92c3ed5afb06c3a8e188cb5da4984cab9ec9a77ba956ee419c68a388b4595255", size = 11252097 },
+    { url = "https://files.pythonhosted.org/packages/f8/b3/8b0f74dfd072c802b7fa368829defdf3ee1566ba74c32a2cb2403f68024c/mypy-1.14.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:dbec574648b3e25f43d23577309b16534431db4ddc09fda50841f1e34e64ed34", size = 10239728 },
+    { url = "https://files.pythonhosted.org/packages/c5/9b/4fd95ab20c52bb5b8c03cc49169be5905d931de17edfe4d9d2986800b52e/mypy-1.14.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8c6d94b16d62eb3e947281aa7347d78236688e21081f11de976376cf010eb31a", size = 11924965 },
+    { url = "https://files.pythonhosted.org/packages/56/9d/4a236b9c57f5d8f08ed346914b3f091a62dd7e19336b2b2a0d85485f82ff/mypy-1.14.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d4b19b03fdf54f3c5b2fa474c56b4c13c9dbfb9a2db4370ede7ec11a2c5927d9", size = 12867660 },
+    { url = "https://files.pythonhosted.org/packages/40/88/a61a5497e2f68d9027de2bb139c7bb9abaeb1be1584649fa9d807f80a338/mypy-1.14.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:0c911fde686394753fff899c409fd4e16e9b294c24bfd5e1ea4675deae1ac6fd", size = 12969198 },
+    { url = "https://files.pythonhosted.org/packages/54/da/3d6fc5d92d324701b0c23fb413c853892bfe0e1dbe06c9138037d459756b/mypy-1.14.1-cp313-cp313-win_amd64.whl", hash = "sha256:8b21525cb51671219f5307be85f7e646a153e5acc656e5cebf64bfa076c50107", size = 9885276 },
+    { url = "https://files.pythonhosted.org/packages/ca/1f/186d133ae2514633f8558e78cd658070ba686c0e9275c5a5c24a1e1f0d67/mypy-1.14.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:3888a1816d69f7ab92092f785a462944b3ca16d7c470d564165fe703b0970c35", size = 11200493 },
+    { url = "https://files.pythonhosted.org/packages/af/fc/4842485d034e38a4646cccd1369f6b1ccd7bc86989c52770d75d719a9941/mypy-1.14.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:46c756a444117c43ee984bd055db99e498bc613a70bbbc120272bd13ca579fbc", size = 10357702 },
+    { url = "https://files.pythonhosted.org/packages/b4/e6/457b83f2d701e23869cfec013a48a12638f75b9d37612a9ddf99072c1051/mypy-1.14.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:27fc248022907e72abfd8e22ab1f10e903915ff69961174784a3900a8cba9ad9", size = 12091104 },
+    { url = "https://files.pythonhosted.org/packages/f1/bf/76a569158db678fee59f4fd30b8e7a0d75bcbaeef49edd882a0d63af6d66/mypy-1.14.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:499d6a72fb7e5de92218db961f1a66d5f11783f9ae549d214617edab5d4dbdbb", size = 12830167 },
+    { url = "https://files.pythonhosted.org/packages/43/bc/0bc6b694b3103de9fed61867f1c8bd33336b913d16831431e7cb48ef1c92/mypy-1.14.1-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:57961db9795eb566dc1d1b4e9139ebc4c6b0cb6e7254ecde69d1552bf7613f60", size = 13013834 },
+    { url = "https://files.pythonhosted.org/packages/b0/79/5f5ec47849b6df1e6943d5fd8e6632fbfc04b4fd4acfa5a5a9535d11b4e2/mypy-1.14.1-cp39-cp39-win_amd64.whl", hash = "sha256:07ba89fdcc9451f2ebb02853deb6aaaa3d2239a236669a63ab3801bbf923ef5c", size = 9781231 },
+    { url = "https://files.pythonhosted.org/packages/a0/b5/32dd67b69a16d088e533962e5044e51004176a9952419de0370cdaead0f8/mypy-1.14.1-py3-none-any.whl", hash = "sha256:b66a60cc4073aeb8ae00057f9c1f64d49e90f918fbcef9a977eb121da8b8f1d1", size = 2752905 },
 ]
 
 [[package]]
@@ -1392,27 +1397,27 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.8.4"
+version = "0.9.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/34/37/9c02181ef38d55b77d97c68b78e705fd14c0de0e5d085202bb2b52ce5be9/ruff-0.8.4.tar.gz", hash = "sha256:0d5f89f254836799af1615798caa5f80b7f935d7a670fad66c5007928e57ace8", size = 3402103 }
+sdist = { url = "https://files.pythonhosted.org/packages/1e/7f/60fda2eec81f23f8aa7cbbfdf6ec2ca11eb11c273827933fb2541c2ce9d8/ruff-0.9.3.tar.gz", hash = "sha256:8293f89985a090ebc3ed1064df31f3b4b56320cdfcec8b60d3295bddb955c22a", size = 3586740 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/05/67/f480bf2f2723b2e49af38ed2be75ccdb2798fca7d56279b585c8f553aaab/ruff-0.8.4-py3-none-linux_armv6l.whl", hash = "sha256:58072f0c06080276804c6a4e21a9045a706584a958e644353603d36ca1eb8a60", size = 10546415 },
-    { url = "https://files.pythonhosted.org/packages/eb/7a/5aba20312c73f1ce61814e520d1920edf68ca3b9c507bd84d8546a8ecaa8/ruff-0.8.4-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:ffb60904651c00a1e0b8df594591770018a0f04587f7deeb3838344fe3adabac", size = 10346113 },
-    { url = "https://files.pythonhosted.org/packages/76/f4/c41de22b3728486f0aa95383a44c42657b2db4062f3234ca36fc8cf52d8b/ruff-0.8.4-py3-none-macosx_11_0_arm64.whl", hash = "sha256:6ddf5d654ac0d44389f6bf05cee4caeefc3132a64b58ea46738111d687352296", size = 9943564 },
-    { url = "https://files.pythonhosted.org/packages/0e/f0/afa0d2191af495ac82d4cbbfd7a94e3df6f62a04ca412033e073b871fc6d/ruff-0.8.4-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e248b1f0fa2749edd3350a2a342b67b43a2627434c059a063418e3d375cfe643", size = 10805522 },
-    { url = "https://files.pythonhosted.org/packages/12/57/5d1e9a0fd0c228e663894e8e3a8e7063e5ee90f8e8e60cf2085f362bfa1a/ruff-0.8.4-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bf197b98ed86e417412ee3b6c893f44c8864f816451441483253d5ff22c0e81e", size = 10306763 },
-    { url = "https://files.pythonhosted.org/packages/04/df/f069fdb02e408be8aac6853583572a2873f87f866fe8515de65873caf6b8/ruff-0.8.4-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c41319b85faa3aadd4d30cb1cffdd9ac6b89704ff79f7664b853785b48eccdf3", size = 11359574 },
-    { url = "https://files.pythonhosted.org/packages/d3/04/37c27494cd02e4a8315680debfc6dfabcb97e597c07cce0044db1f9dfbe2/ruff-0.8.4-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:9f8402b7c4f96463f135e936d9ab77b65711fcd5d72e5d67597b543bbb43cf3f", size = 12094851 },
-    { url = "https://files.pythonhosted.org/packages/81/b1/c5d7fb68506cab9832d208d03ea4668da9a9887a4a392f4f328b1bf734ad/ruff-0.8.4-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e4e56b3baa9c23d324ead112a4fdf20db9a3f8f29eeabff1355114dd96014604", size = 11655539 },
-    { url = "https://files.pythonhosted.org/packages/ef/38/8f8f2c8898dc8a7a49bc340cf6f00226917f0f5cb489e37075bcb2ce3671/ruff-0.8.4-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:736272574e97157f7edbbb43b1d046125fce9e7d8d583d5d65d0c9bf2c15addf", size = 12912805 },
-    { url = "https://files.pythonhosted.org/packages/06/dd/fa6660c279f4eb320788876d0cff4ea18d9af7d9ed7216d7bd66877468d0/ruff-0.8.4-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e5fe710ab6061592521f902fca7ebcb9fabd27bc7c57c764298b1c1f15fff720", size = 11205976 },
-    { url = "https://files.pythonhosted.org/packages/a8/d7/de94cc89833b5de455750686c17c9e10f4e1ab7ccdc5521b8fe911d1477e/ruff-0.8.4-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:13e9ec6d6b55f6da412d59953d65d66e760d583dd3c1c72bf1f26435b5bfdbae", size = 10792039 },
-    { url = "https://files.pythonhosted.org/packages/6d/15/3e4906559248bdbb74854af684314608297a05b996062c9d72e0ef7c7097/ruff-0.8.4-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:97d9aefef725348ad77d6db98b726cfdb075a40b936c7984088804dfd38268a7", size = 10400088 },
-    { url = "https://files.pythonhosted.org/packages/a2/21/9ed4c0e8133cb4a87a18d470f534ad1a8a66d7bec493bcb8bda2d1a5d5be/ruff-0.8.4-py3-none-musllinux_1_2_i686.whl", hash = "sha256:ab78e33325a6f5374e04c2ab924a3367d69a0da36f8c9cb6b894a62017506111", size = 10900814 },
-    { url = "https://files.pythonhosted.org/packages/0d/5d/122a65a18955bd9da2616b69bc839351f8baf23b2805b543aa2f0aed72b5/ruff-0.8.4-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:8ef06f66f4a05c3ddbc9121a8b0cecccd92c5bf3dd43b5472ffe40b8ca10f0f8", size = 11268828 },
-    { url = "https://files.pythonhosted.org/packages/43/a9/1676ee9106995381e3d34bccac5bb28df70194167337ed4854c20f27c7ba/ruff-0.8.4-py3-none-win32.whl", hash = "sha256:552fb6d861320958ca5e15f28b20a3d071aa83b93caee33a87b471f99a6c0835", size = 8805621 },
-    { url = "https://files.pythonhosted.org/packages/10/98/ed6b56a30ee76771c193ff7ceeaf1d2acc98d33a1a27b8479cbdb5c17a23/ruff-0.8.4-py3-none-win_amd64.whl", hash = "sha256:f21a1143776f8656d7f364bd264a9d60f01b7f52243fbe90e7670c0dfe0cf65d", size = 9660086 },
-    { url = "https://files.pythonhosted.org/packages/13/9f/026e18ca7d7766783d779dae5e9c656746c6ede36ef73c6d934aaf4a6dec/ruff-0.8.4-py3-none-win_arm64.whl", hash = "sha256:9183dd615d8df50defa8b1d9a074053891ba39025cf5ae88e8bcb52edcc4bf08", size = 9074500 },
+    { url = "https://files.pythonhosted.org/packages/f9/77/4fb790596d5d52c87fd55b7160c557c400e90f6116a56d82d76e95d9374a/ruff-0.9.3-py3-none-linux_armv6l.whl", hash = "sha256:7f39b879064c7d9670197d91124a75d118d00b0990586549949aae80cdc16624", size = 11656815 },
+    { url = "https://files.pythonhosted.org/packages/a2/a8/3338ecb97573eafe74505f28431df3842c1933c5f8eae615427c1de32858/ruff-0.9.3-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:a187171e7c09efa4b4cc30ee5d0d55a8d6c5311b3e1b74ac5cb96cc89bafc43c", size = 11594821 },
+    { url = "https://files.pythonhosted.org/packages/8e/89/320223c3421962762531a6b2dd58579b858ca9916fb2674874df5e97d628/ruff-0.9.3-py3-none-macosx_11_0_arm64.whl", hash = "sha256:c59ab92f8e92d6725b7ded9d4a31be3ef42688a115c6d3da9457a5bda140e2b4", size = 11040475 },
+    { url = "https://files.pythonhosted.org/packages/b2/bd/1d775eac5e51409535804a3a888a9623e87a8f4b53e2491580858a083692/ruff-0.9.3-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2dc153c25e715be41bb228bc651c1e9b1a88d5c6e5ed0194fa0dfea02b026439", size = 11856207 },
+    { url = "https://files.pythonhosted.org/packages/7f/c6/3e14e09be29587393d188454064a4aa85174910d16644051a80444e4fd88/ruff-0.9.3-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:646909a1e25e0dc28fbc529eab8eb7bb583079628e8cbe738192853dbbe43af5", size = 11420460 },
+    { url = "https://files.pythonhosted.org/packages/ef/42/b7ca38ffd568ae9b128a2fa76353e9a9a3c80ef19746408d4ce99217ecc1/ruff-0.9.3-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5a5a46e09355695fbdbb30ed9889d6cf1c61b77b700a9fafc21b41f097bfbba4", size = 12605472 },
+    { url = "https://files.pythonhosted.org/packages/a6/a1/3167023f23e3530fde899497ccfe239e4523854cb874458ac082992d206c/ruff-0.9.3-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:c4bb09d2bbb394e3730d0918c00276e79b2de70ec2a5231cd4ebb51a57df9ba1", size = 13243123 },
+    { url = "https://files.pythonhosted.org/packages/d0/b4/3c600758e320f5bf7de16858502e849f4216cb0151f819fa0d1154874802/ruff-0.9.3-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:96a87ec31dc1044d8c2da2ebbed1c456d9b561e7d087734336518181b26b3aa5", size = 12744650 },
+    { url = "https://files.pythonhosted.org/packages/be/38/266fbcbb3d0088862c9bafa8b1b99486691d2945a90b9a7316336a0d9a1b/ruff-0.9.3-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9bb7554aca6f842645022fe2d301c264e6925baa708b392867b7a62645304df4", size = 14458585 },
+    { url = "https://files.pythonhosted.org/packages/63/a6/47fd0e96990ee9b7a4abda62de26d291bd3f7647218d05b7d6d38af47c30/ruff-0.9.3-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cabc332b7075a914ecea912cd1f3d4370489c8018f2c945a30bcc934e3bc06a6", size = 12419624 },
+    { url = "https://files.pythonhosted.org/packages/84/5d/de0b7652e09f7dda49e1a3825a164a65f4998175b6486603c7601279baad/ruff-0.9.3-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:33866c3cc2a575cbd546f2cd02bdd466fed65118e4365ee538a3deffd6fcb730", size = 11843238 },
+    { url = "https://files.pythonhosted.org/packages/9e/be/3f341ceb1c62b565ec1fb6fd2139cc40b60ae6eff4b6fb8f94b1bb37c7a9/ruff-0.9.3-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:006e5de2621304c8810bcd2ee101587712fa93b4f955ed0985907a36c427e0c2", size = 11484012 },
+    { url = "https://files.pythonhosted.org/packages/a3/c8/ff8acbd33addc7e797e702cf00bfde352ab469723720c5607b964491d5cf/ruff-0.9.3-py3-none-musllinux_1_2_i686.whl", hash = "sha256:ba6eea4459dbd6b1be4e6bfc766079fb9b8dd2e5a35aff6baee4d9b1514ea519", size = 12038494 },
+    { url = "https://files.pythonhosted.org/packages/73/b1/8d9a2c0efbbabe848b55f877bc10c5001a37ab10aca13c711431673414e5/ruff-0.9.3-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:90230a6b8055ad47d3325e9ee8f8a9ae7e273078a66401ac66df68943ced029b", size = 12473639 },
+    { url = "https://files.pythonhosted.org/packages/cb/44/a673647105b1ba6da9824a928634fe23186ab19f9d526d7bdf278cd27bc3/ruff-0.9.3-py3-none-win32.whl", hash = "sha256:eabe5eb2c19a42f4808c03b82bd313fc84d4e395133fb3fc1b1516170a31213c", size = 9834353 },
+    { url = "https://files.pythonhosted.org/packages/c3/01/65cadb59bf8d4fbe33d1a750103e6883d9ef302f60c28b73b773092fbde5/ruff-0.9.3-py3-none-win_amd64.whl", hash = "sha256:040ceb7f20791dfa0e78b4230ee9dce23da3b64dd5848e40e3bf3ab76468dcf4", size = 10821444 },
+    { url = "https://files.pythonhosted.org/packages/69/cb/b3fe58a136a27d981911cba2f18e4b29f15010623b79f0f2510fd0d31fd3/ruff-0.9.3-py3-none-win_arm64.whl", hash = "sha256:800d773f6d4d33b0a3c60e2c6ae8f4c202ea2de056365acfa519aa48acf28e0b", size = 10038168 },
 ]
 
 [[package]]


### PR DESCRIPTION
Fields in the table can now be a list, dict, tuple or set in addition to the existing types. Internally, they are `pickled` to preserve complex sub-types - this is transparent to the user.

See the doc site for usage examples

