### PR TITLE
migrate license metadata to latest standards

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,13 +8,13 @@ description = "Interact with SQLite databases using Python and Pydantic, with op
 readme = "README.md"
 requires-python = ">=3.10"
 license = "MIT"
+license-files = ["LICENSE.txt"]
 authors = [{ name = "Grant Ramsay", email = "grant@gnramsay.com" }]
 dependencies = ["pydantic>=2.12.5"]
 
 classifiers = [
   "Development Status :: 4 - Beta",
   "Intended Audience :: Developers",
-  "License :: OSI Approved :: MIT License",
   "Operating System :: OS Independent",
   "Programming Language :: Python :: 3",
   "Programming Language :: Python :: 3.10",


### PR DESCRIPTION
Change the license metadata in `pyproject.toml` to follow the latest PEP 639 standards